### PR TITLE
Optimize event based IO file creation

### DIFF
--- a/rtl/rtl_iofile.py
+++ b/rtl/rtl_iofile.py
@@ -17,6 +17,7 @@ from thesdk import *
 from thesdk.iofile import iofile
 import numpy as np
 import pandas as pd
+import sortedcontainers as sc
 from rtl.connector import intend
 
 class rtl_iofile(iofile):
@@ -65,6 +66,8 @@ class rtl_iofile(iofile):
 
         except:
             self.print_log(type='F', msg="Verilog IO file definition failed")
+
+        self._DictData = None  # data structure for event-based IO data
 
 
     #Overload from iofile package
@@ -251,7 +254,9 @@ class rtl_iofile(iofile):
         return self._verilog_connector_datamap[name]
 
     def set_control_data(self,**kwargs):
-        '''Method to define event based data value with name,time, and value.
+        '''Method to define event based data value with name, time, and value.
+        Uses a python dictionary instead of a numpy array for more efficient insertions.
+        The 'time' column acts as the dictionary key, the remaining columns are stored as the value.
 
         Parameters
         ----------
@@ -267,26 +272,72 @@ class rtl_iofile(iofile):
         name=kwargs.get('name')
         val=kwargs.get('val')
         init=kwargs.get('init',int(0))
-        
-        # First, we initialize the data
-        if self.Data is None:
-            if np.isscalar(init):
-                self.Data=(np.ones((1,len(self._verilog_connectors)+1))*init).astype(int)
-                self.Data[0,0]=int(time)
-            elif init.shape[1]==len(self._verilog_connectors)+1:
-                self.Data=init.astype(int)
-        else: #Lets manipulate
-            index=np.where(self.Data[:,0]==time)[0]
-            if index.size > 0:
-                # Alter existing value onwards from given time
-                self.Data[index[-1]:,self.connector_datamap(name=name)]=int(val)
-            else:
-                # Find the previous time, duplicate the row and alter the value
-                previndex=np.where(self.Data[:,0]<time)[0][-1]
-                self.Data=np.r_['0', self.Data[0:previndex+1,:], self.Data[previndex::,:]]
-                self.Data[previndex+1,0]=time
-                self.Data[previndex+1,self.connector_datamap(name=name)]=val
 
+        # sanity checks
+        assert isinstance(time, int), "Argument 'time' should have the type 'int'"
+
+        # Init Data and add first element
+        if self.DictData is None:
+            self.DictData = sc.SortedDict()
+            if np.isscalar(init):
+                self.DictData[0] = (np.ones(len(self._verilog_connectors))*init).astype(int)
+            elif init.shape[1] == len(self._verilog_connectors)+1:
+                init_array = init.astype(int)
+                for row in init_array:
+                    self.DictData[row[0]] = row[1:]
+        # Add subsequent elements as diffs as follows:
+        # None -- no change
+        # int -- change signal to the given value
+        else:
+            # add a new row if the time is not yet in the dictionary
+            if time not in self.DictData:
+                # init diff as no change
+                self.DictData[time] = [None for _ in range(len(self._verilog_connectors))]
+
+            # change corresponding value
+            self.DictData[time][self.connector_datamap(name=name)-1] = val
+
+    # Overload self.Data accessors to keep them consistent with the assumption of using numpy arrays
+    # To hold IO data. These methods convert to and from the diff-based data structure used in this
+    # module. I.e. the self.Data property will look like an numpy array as seen from external modules
+    # while in reality it's using the more efficient SortedDict implementation internally.
+
+    # Getter - This takes the difference based format stored in DictData and converts it to a numpy array
+    @property
+    def Data(self):
+        if not hasattr(self, '_Data'):
+            self._Data=None
+
+        # build a numpy array from the dict and sort it by time column
+        diff_array = np.array([np.insert(signals, 0, time) for (time, signals) in self.DictData.items()])
+
+        # populate None values from previous timestamps
+        transposed = np.transpose(diff_array)
+        for i in range(1, transposed.shape[0]):
+            for j in range(1, transposed.shape[1]):
+                if transposed[i,j] is None:
+                    transposed[i,j] = transposed[i, j-1]
+        io_array = np.transpose(transposed).astype(int)
+
+        return io_array
+
+    # Setter - Takes a numpy array and converts it to the diff-based SortedDict
+    @Data.setter
+    def Data(self, value):
+        # convert value to equivalent SortedDict representation
+        self.DictData = sc.SortedDict()
+        for row in value:
+            self.DictData[row[0]] = row[1:]
+
+    @property
+    def DictData(self):
+        if not hasattr(self, '_Data'):
+            self._DictData=None
+        return self._DictData
+
+    @DictData.setter
+    def DictData(self, value):
+        self._DictData = value
 
     # Condition string for monitoring if the signals are unknown
     @property 


### PR DESCRIPTION
The current `set_control_data` has some performance issues on larger input data sets. These are mainly associated with two numpy array operations:
1. Searching an array for a certain timestamp `np.where(...)`
2. Duplicating the array to insert new rows `np.r_[]`

These expensive operations stack up on larger inputs. For example, when simulating `jtag_programmer` with an 800 byte executable, the sydekick spends around 5 minutes in `set_control_data` before even starting the simulation.

This PR implements a more efficient dictionary based approach for generating the numpy array for the IO file. Essentialy, events are stored in a dictionary data structure ([SortedDict](http://www.grantjenks.com/docs/sortedcontainers/sorteddict.html)) for more efficient insertions, and they are encoded as diffs at that time. This eliminates the need to update any other array values when inserting a new event.

After this optimization, the IO file generation takes only about 3 seconds.

The use of a different data structures has some friction with the assumption that numpy arrays are used for the IO files in the `Data` property. Currently, this has been solved by overriding the `Data` accessors in a way that converts between the dictionary based data structure and numpy arrays so that external modules need not be aware of this implementation. However, this can be still changed if someone has a better solution.

Depends on [thesdk_helpers/pull/8](https://github.com/TheSystemDevelopmentKit/thesdk_helpers/pull/8) for `SortedDict`.

cc @mkosunen 