### PR TITLE
Use verilog time type for event timestamps

### DIFF
--- a/rtl/rtl_iofile.py
+++ b/rtl/rtl_iofile.py
@@ -174,9 +174,8 @@ class rtl_iofile(iofile):
         if self.iotype=='sample':
             self._verilog_statdef='integer %s, %s;\n' %(self.verilog_stat, self.verilog_fptr)
         elif self.iotype=='event':
-            self._verilog_statdef='integer %s, %s, %s, %s, %s;\n' %(self.verilog_stat, 
-                    self.verilog_fptr, self.verilog_ctstamp, self.verilog_ptstamp, 
-                    self.verilog_tdiff)
+            self._verilog_statdef='integer %s, %s;\n' %(self.verilog_stat, self.verilog_fptr)
+            self._verilog_statdef+='time %s, %s, %s;\n' %(self.verilog_ctstamp, self.verilog_ptstamp, self.verilog_tdiff)
             self._verilog_statdef+='initial %s=0;\n' %(self.verilog_ctstamp) 
             self._verilog_statdef+='initial %s=0;\n' %(self.verilog_ptstamp) 
             for connector in self.verilog_connectors:


### PR DESCRIPTION
Modelsim uses 64-bit integers internally to represent time. Apparently the verilog `integer` type is only 32-bits wide and is small enough to overflow on long simulations that use controller defined event IO. This patch changes the time-related testbench variables to use the `time` type instead which is guaranteed to be at least 64 bits wide by the verilog spec (IEEE Std 1364™-2005, section 4.8).

ping @mkosunen 