### PR TITLE
Copy simulations sources to `simulations/` when running RTL simulations

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -58,9 +58,9 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
         debugging testbench generation.
         
         """
-        if not hasattr(self,'_preserve_iofiles'):
+        if not hasattr(self,'_preserve_rtlfiles'):
             self._preserve_rtlfiles=False
-        return self._preserve_iofiles
+        return self._preserve_rtlfiles
     @preserve_rtlfiles.setter
     def preserve_rtlfiles(self,value):
         self._preserve_rtlfiles=value

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -319,6 +319,15 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
             self._rtlworkpath = self.simpath +'/work'
         return self._rtlworkpath
 
+    @rtlworkpath.deleter
+    def rtlworkpath(self):
+        if os.path.exists(self.rtlworkpath):
+            try:
+                shutil.rmtree(self.rtlworkpath)
+                self.print_log(type='D',msg='Removing %s' % self.rtlworkpath)
+            except:
+                self.print_log(type='W',msg='Could not remove %s' %self.rtlworkpath)
+
     @property
     def rtlparameters(self): 
         '''Dictionary of parameters passed to the simulator 
@@ -704,6 +713,7 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
            11) Executes the simulation
            12) Read outputfiles 
            13) Connects the outputs
+           14) Cleans up the intermediate files
 
            You should overload this method while creating the simulation 
            and debugging the testbench.
@@ -737,6 +747,7 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
             if not self.preserve_iofiles:
                 del(self.iofile_bundle)
             if not self.preserve_rtlfiles:
+                del(self.rtlworkpath)
                 del(self.rtlsimpath)
 
 

--- a/rtl/module.py
+++ b/rtl/module.py
@@ -109,6 +109,7 @@ class verilog_module(thesdk):
             dut=''
             # Extract the module definition
             self._ios=verilog_connector_bundle()
+            self.print_log(type='I', msg="{}".format(self.file))
             if os.path.isfile(self.file):
                 with open(self.file) as infile:
                     wholefile=infile.readlines()
@@ -168,6 +169,8 @@ class verilog_module(thesdk):
                             signal.connect.connect=signal
 
                             self._ios.Members[signal.name]=signal
+            else:
+                self.print_log(type='F', msg='File does not exist: %s' % self.file)
         return self._ios
 
     # Setting principle, assign a dict

--- a/rtl/testbench.py
+++ b/rtl/testbench.py
@@ -50,15 +50,19 @@ class testbench(verilog_module):
               None
 
         '''
+
         if parent==None:
             self.print_log(type='F', msg="Parent of Verilog testbench not given")
         else:
             self.parent=parent
         try:  
             # Testbench is always verilog
-            self._file=self.parent.vlogsrcpath + '/tb_' + self.parent.name + '.sv'
+            self._file=self.parent.simvlogpath + '/tb_' + self.parent.name + '.sv'
             if self.parent.model=='sv':
-                self._dutfile=self.parent.vlogsrcpath + '/' + self.parent.name + '.sv'
+                if parent.generate_verilog:
+                    self._dutfile=self.parent.simvlogpath+ '/' + self.parent.name + '.v'
+                else:
+                    self._dutfile=self.parent.simvlogpath+ '/' + self.parent.name + '.sv'
             elif self.parent.model=='vhdl':
                 self._dutfile=self.parent.vhdlsrcpath + '/' + self.parent.name + '.vhd'
 

--- a/rtl/testbench.py
+++ b/rtl/testbench.py
@@ -56,16 +56,9 @@ class testbench(verilog_module):
         else:
             self.parent=parent
         try:  
-            # Testbench is always verilog
-            self._file=self.parent.simvlogpath + '/tb_' + self.parent.name + '.sv'
-            if self.parent.model=='sv':
-                if parent.generate_verilog:
-                    self._dutfile=self.parent.simvlogpath+ '/' + self.parent.name + '.v'
-                else:
-                    self._dutfile=self.parent.simvlogpath+ '/' + self.parent.name + '.sv'
-            elif self.parent.model=='vhdl':
-                self._dutfile=self.parent.vhdlsrcpath + '/' + self.parent.name + '.vhd'
-
+            # The proper files are determined in rtl based on simulation model
+            self._file = self.parent.simtb
+            self._dutfile = self.parent.simdut
         except:
             self.print_log(type='F', msg="Verilog Testbench file definition failed")
         


### PR DESCRIPTION
This pull request adds first-class support for configuring an rtl entity as a Chisel generator enabled by the property `generate_verilog`. The command line arguments to the chisel generator are passed over the `chiselargs` property as a dict. To support (potentially concurrent) access from multiple user entities, the generated verilog files are placed in a temporary file under the `simulations/` directory. The chisel to verilog elaboration is executed as a part of `run_rtl()` so the entity transparently acts as a  Chisel designs whose parameters can be controlled from python without having to think about the verilog output.

The general approach is to change the simulation execution routine to:
1) First copy all verilog and vhdl sources under the temporary simulation directory
2) Invoke the Chisel generator command, which potentially overwrites the hard-coded source
3) Generate simulation testbench under the temporary simulations directory
4) Remaining steps are left unchanged.

This is still a work in progress, and at least I have not paid any attention into whether this breaks vhdl simulation. Contributions and improvement suggestions are welcome.

cc @mkosunen 
