### PR TITLE
Check for existing sources before copying

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -607,8 +607,11 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
             for modfile in self.vlogmodulefiles:
                 srcfile = os.path.join(self.vlogsrcpath, modfile)
                 dstfile = os.path.join(self.rtlsimpath, modfile)
-                self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
-                shutil.copyfile(srcfile, dstfile)
+                if os.path.isfile(dstfile):
+                    self.print_log(type='I', msg='Using externally generated source: %s' % modfile)
+                else:
+                    self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
+                    shutil.copyfile(srcfile, dstfile)
 
         # nothing generates vhdl so simply copy all files to rtlsimpath
         elif self.model == 'vhdl':
@@ -616,8 +619,11 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
             for entfile in self.vhdlentityfiles:
                 srcfile = os.path.join(self.vlogsrcpath, entfile)
                 dstfile = os.path.join(self.rtlsimpath, entfile)
-                self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
-                shutil.copyfile(srcfile, dstfile)
+                if os.path.isfile(dstfile):
+                    self.print_log(type='I', msg='Using externally generated source: %s' % entfile)
+                else:
+                    self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
+                    shutil.copyfile(srcfile, dstfile)
 
         # flush cached writes to disk
         output = subprocess.check_output("sync %s" % self.rtlsimpath, shell=True)


### PR DESCRIPTION
Currently, the when copying sources to simulation folder externally generated sources only work for the module which has the same name as the entity. This should not be a special case, since other modules, e.g. black-boxed verilog in Chisel, are also externally generated. In particular, Chisel generates a verilog source file for each black-boxed module. It should be possible to use the `vlogmodulefiles` attribute to specify these additional sources so the existence of these files should be checked as well before trying to copy them from the entity verilog source directory.