### PR TITLE
Add vlogcompargs to pass arguments during verilog compilation

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -443,7 +443,7 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
 
         if self.model=='sv':
             vlogcompcmd = ( 'vlog -sv -work work ' + vlogmodulesstring 
-                    + ' ' + self.simdut + ' ' + self.simtb )
+                    + ' ' + self.simdut + ' ' + self.simtb + ' +define+RANDOMIZE_REG_INIT')
         elif self.model=='vhdl':
             vlogcompcmd = ( 'vlog -sv -work work ' + vlogmodulesstring 
                     + ' ' + self.simtb )
@@ -474,7 +474,7 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
                 self.print_log(type='I',msg='No interactive control file set.')
             submission="" #Local execution
             rtlsimcmd = ( 'vsim -64 -t ' + self.rtl_timescale + ' -novopt ' + fileparams 
-                    + ' ' + gstring +' work.tb_' + self.name + dostring)
+                    + ' ' + gstring +' work.tb_' + self.name + dostring )
 
         if self.model=='sv':
             self._rtlcmd =  rtllibcmd  +\

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -304,6 +304,17 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
                 self.print_log(type='W',msg='Could not remove %s' %self.rtlworkpath)
 
     @property
+    def vlogcompargs(self):
+        ''' List of arguments passed to the simulator
+        during the verilog compilation '''
+        if not hasattr(self, '_vlogcompargs'):
+            self._vlogcompargs = []
+        return self._vlogcompargs
+    @vlogcompargs.setter
+    def vlogcompargs(self, value):
+        self._vlogcompargs = value
+
+    @property
     def rtlparameters(self): 
         '''Dictionary of parameters passed to the simulator 
         during the simulation invocation
@@ -443,7 +454,7 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
 
         if self.model=='sv':
             vlogcompcmd = ( 'vlog -sv -work work ' + vlogmodulesstring 
-                    + ' ' + self.simdut + ' ' + self.simtb + ' +define+RANDOMIZE_REG_INIT')
+                    + ' ' + self.simdut + ' ' + self.simtb + ' ' + ' '.join(self.vlogcompargs))
         elif self.model=='vhdl':
             vlogcompcmd = ( 'vlog -sv -work work ' + vlogmodulesstring 
                     + ' ' + self.simtb )


### PR DESCRIPTION
This PR adds the `vlogcompargs` field to `rtl` for specifying arbitrary arguments for verilog compilation phase.

## Background
Some verilog directives, such as `` `ifdef `` are evaluated at compile-time. For example, Chisel-generated verilog contain structures for initializing registers to random values in simulation if `RANDOMIZE_REG_INIT` is defined.

```verilog
`ifdef RANDOMIZE_REG_INIT
  _RAND_0 = {1{`RANDOM}};
  regs_0 = _RAND_0[0:0];
`endif // RANDOMIZE_REG_INIT
```

This is useful for simulating designs which don't rely on explicit reset signals. For example, a JTAG TAP can be reset to a known state by holding the `TMS` input high and cycling `TCK` at least five times. Without register randomization, the state variable will be init as logic `X` which is propagated by the simulator instead of allowing the random init value to settle to a known state through the TMS reset routine.

## Usage Example
 For example, the randomize define can be set with
```python
self.vlogcompargs = ["+define+RANDOMIZE_REG_INIT"]
```