### PR TITLE
Improvements for Verilog testbench indentation

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -22,7 +22,7 @@ import pandas as pd
 from functools import reduce
 import shutil
 
-from rtl.connector import intend
+from rtl.connector import indent
 from rtl.testbench import testbench as vtb
 from rtl.rtl_iofile import rtl_iofile as rtl_iofile
 

--- a/rtl/connector.py
+++ b/rtl/connector.py
@@ -112,7 +112,7 @@ class verilog_connector_bundle(Bundle):
         for name, value in self.Members.items():
             if re.match(match,name):
                 assignments=assignments+value.assignment
-        return intend(text=assignments, level=kwargs.get('level',0))
+        return indent(text=assignments, level=kwargs.get('level',0))
 
     def verilog_inits(self,**kwargs):
         #[TODO]: Write sanity checks
@@ -121,7 +121,7 @@ class verilog_connector_bundle(Bundle):
         for name, val in self.Members.items():
             if re.match(match,name) and ( val.init is not None and val.init is not '' ):
                 inits=inits+'%s = %s;\n' %(val.name,val.init)
-        return intend(text=inits, level=kwargs.get('level',0))
+        return indent(text=inits, level=kwargs.get('level',0))
 
     def list(self,**kwargs):
         #[TODO]: Write sanity checks
@@ -132,15 +132,30 @@ class verilog_connector_bundle(Bundle):
                 connectors.append(self.Members[name])
         return connectors
 
-#Helper to intend text blocks
-def intend(**kwargs):
+#Helper to indent text blocks
+def indent(**kwargs):
+    '''
+    Helper for indenting text blocks
+    Also adds a newline after every line (including last one)
+    Parameters
+    -----------
+    **kwargs : 
+        text  : text to indent (may allow line breaks)
+        level : level of indent (level * 4 spaces will be added to each row)
+    '''
+    text = kwargs.get('text', '')
+    nspaces = 4
+    level = kwargs.get('level', 0)
     textout=''
-    nspaces=4
-    for line in (kwargs.get('text')).splitlines():
-        for _ in range(nspaces*kwargs.get('level')):
-            line=line+' '
-        textout=textout+line+'\n'
+    for line in text.splitlines():
+        spaces = ' ' * nspaces*level
+        textout += spaces+line+'\n'
     return textout
+
+# Support the old name for backwards compatibility
+def intend(**kwargs):
+    return indent(**kwargs)
+
 
 if __name__=="__main__":
     pass

--- a/rtl/rtl_iofile.py
+++ b/rtl/rtl_iofile.py
@@ -18,7 +18,7 @@ from thesdk.iofile import iofile
 import numpy as np
 import pandas as pd
 import sortedcontainers as sc
-from rtl.connector import intend
+from rtl.connector import indent
 
 class rtl_iofile(iofile):
     '''
@@ -425,26 +425,26 @@ class rtl_iofile(iofile):
         first=True
         if self.iotype=='sample':
             if self.dir=='out':
-                self._verilog_io=' always '+self.verilog_io_sync +'begin\n'
-                self._verilog_io+='if ( %s ) begin\n' %(self.verilog_io_condition)
-                self._verilog_io+='$fwrite(%s, ' %(self.verilog_fptr)
+                self._verilog_io='always '+self.verilog_io_sync +'begin\n'
+                self._verilog_io+=indent(text='if ( %s ) begin\n' %(self.verilog_io_condition), level=1)
+                self._verilog_io+=indent(text='$fwrite(%s, ' %(self.verilog_fptr), level=2)
             elif self.dir=='in':
                 self._verilog_io='while (!$feof(f_%s)) begin\n' %self.name
-                self._verilog_io+='   %s' %self.verilog_io_sync
-                self._verilog_io+='        if ( %s ) begin\n' %self.verilog_io_condition      
-                self._verilog_io+='        %s = $fscanf(%s, ' \
-                        %(self.verilog_stat, self.verilog_fptr)
+                self._verilog_io+=indent(text='%s' %self.verilog_io_sync, level=0)
+                self._verilog_io+=indent(text='if ( %s ) begin\n' %self.verilog_io_condition, level=1)
+                self._verilog_io+=indent(text='%s = $fscanf(%s, ' \
+                        %(self.verilog_stat, self.verilog_fptr), level=2)
             for connector in self.verilog_connectors:
                 if first:
-                    iolines='    %s' %(connector.name)
+                    iolines='%s' %(connector.name)
                     format='\"%s' %(connector.ioformat)
                     first=False
                 else:
-                    iolines='%s,\n    %s' %(iolines,connector.name)
+                    iolines='%s,\n%s' %(iolines,connector.name)
                     format='%s\\t%s' %(format,connector.ioformat)
 
             format=format+'\\n\",\n'
-            self._verilog_io+=format+iolines+'\n);\n        end\n    end\n'
+            self._verilog_io+=indent(text=format+iolines+'\n);',level=2)+indent(text='end', level=1)+indent(text='end', level=0)
 
         #Control files are handled differently
         elif self.iotype=='event':

--- a/rtl/testbench.py
+++ b/rtl/testbench.py
@@ -21,7 +21,7 @@ from thesdk import *
 from rtl import *
 from rtl.connector import verilog_connector
 from rtl.connector import verilog_connector_bundle
-from rtl.connector import intend 
+from rtl.connector import indent
 from rtl.module import verilog_module
 from rtl.entity import vhdl_entity
 
@@ -170,7 +170,7 @@ class testbench(verilog_module):
         assigns='\n//Assignments\n'
         for match in matchlist:
             assigns=assigns+self.connectors.assign(match=match)
-        return intend(text=assigns,level=kwargs.get('level',0))
+        return indent(text=assigns,level=kwargs.get('level',0))
      
     @property
     def iofile_definitions(self):
@@ -330,7 +330,7 @@ self.dut_instance.instance
         contents+="""
 
 //io_out
-        """
+"""
         for key, member in self.iofiles.Members.items():
             if member.dir=='out':
                 contents+=member.verilog_io
@@ -345,11 +345,11 @@ self.connectors.verilog_inits(level=1)+\
 
     // Sequences enabled by initdone
     $display("Ready to read"); 
-    """
+"""
 
         for key, member in self.iofiles.Members.items():
             if member.dir=='in':
-                contents+=member.verilog_io
+                contents+=indent(text=member.verilog_io, level=1)
 
         contents+='\njoin\n'+self.iofile_close+'\n$finish;\nend\n'
         self.contents=contents


### PR DESCRIPTION
Improves indentation in Verilog testbench. Also renamed the function from `intend` to `indent` while also maintaining support for the old function name.

Did not yet test with the inverter example.