### PR TITLE
Add support for custom connectors

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -715,7 +715,7 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
     def custom_connectors(self, bundle):
         self._custom_connectors = bundle
 
-    def add_custom_connectors(self):
+    def add_connectors(self):
         '''Adds custom connectors to the testbench. 
         Also connects rtl matchlist to testbench matchlist.
         Custom connectors should be saved in self.custom_connectors
@@ -751,7 +751,7 @@ class rtl(thesdk,metaclass=abc.ABCMeta):
             self.copy_rtl_sources()
             self.tb=vtb(self)             
             self.tb.define_testbench()    
-            self.add_custom_connectors()
+            self.add_connectors()
             self.create_connectors()
             self.connect_inputs()         
 


### PR DESCRIPTION
Adds self.custom_connectors property, where the user can define a custom
verilog_connector_bundle that will be updated to testbench connectors.
Also adds self.add_custom_connectors() method to run_rtl().
Also, adds self.assignment_matchlist to rtl level. It used to reside in
testbench, but I could not figure out a proper way to add it nicely from
DUT side when using only that structure.

This modification allows connecting IOFile signals to internal signals. I used this
structure to connect an internal register signal
`ACoreChip.core.regfile_block.regfile.x_10` to an IOFile signal a0. The
register contents get stored into the file.