### PR TITLE
Cosimulation of Verilog top + VHDL external files

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -438,6 +438,16 @@ class rtl(questasim,icarus,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                     self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
                     shutil.copyfile(srcfile, dstfile, follow_symlinks=False)
 
+            # copy additional VHDL files 
+            for entfile in self.vhdlentityfiles:
+                srcfile = os.path.join(self.vhdlsrcpath, entfile)
+                dstfile = os.path.join(self.rtlsimpath, entfile)
+                if os.path.isfile(dstfile):
+                    self.print_log(type='I', msg='Using externally generated source: %s' % entfile)
+                else:
+                    self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
+                    shutil.copyfile(srcfile, dstfile)
+
         # nothing generates vhdl so simply copy all files to rtlsimpath
         elif self.model == 'vhdl':
             shutil.copy(self.vhdlsrc, self.rtlsimpath, follow_symlinks=False)

--- a/rtl/icarus/icarus.py
+++ b/rtl/icarus/icarus.py
@@ -9,6 +9,10 @@ class icarus(sv,thesdk,metaclass=abc.ABCMeta):
             str(param) for param in self.vlogmodulefiles])
         vhdlmodulesstring=' '.join([ self.rtlsimpath + '/'+ 
             str(param) for param in self.vhdlentityfiles])
+
+        if vhdlmodulesstring != '':
+            self.print_log(type='W', msg="Icarus does not support Verilog+VHDL cosimulation, ignoring additional VHDL files.")
+
         vlogcompcmd = ( 'iverilog -Wall -v -g2012 -o ' + self.rtlworkpath + '/' + self.name
     	            + ' ' + self.simtb + ' ' + self.simdut + ' ' + vlogmodulesstring)
         gstring=' '.join([ ('-g ' + str(param) +'='+ str(val)) 

--- a/rtl/questasim/questasim.py
+++ b/rtl/questasim/questasim.py
@@ -52,6 +52,7 @@ class questasim(thesdk,metaclass=abc.ABCMeta):
                     + ' ' + vlogsimargs + ' work.tb_' + self.name  
                     + dostring)
         else:
+            submission = ''
             rtlsimcmd = ( 'vsim -64 -t ' + self.rtl_timescale + ' -novopt ' + fileparams 
                     + ' ' + gstring + ' ' + vlogsimargs + ' work.tb_' + self.name + dostring )
 
@@ -102,6 +103,7 @@ class questasim(thesdk,metaclass=abc.ABCMeta):
                     + ' ' + vlogsimargs + ' work.tb_' + self.name  
                     + dostring)
         else:
+            submission = ''
             rtlsimcmd = ( 'vsim -64 -t ' + self.rtl_timescale + ' -novopt ' + fileparams 
                     + ' ' + gstring + ' ' + vlogsimargs + ' work.tb_' + self.name + dostring )
 

--- a/rtl/vhdl/vhdl.py
+++ b/rtl/vhdl/vhdl.py
@@ -41,6 +41,19 @@ class vhdl(thesdk,metaclass=abc.ABCMeta):
         return self._vhdlsrc
 
     @property
+    def vhdlcompargs(self):
+        ''' List of arguments passed to the simulator
+        during VHDL compilation
+        
+        '''
+        if not hasattr(self, '_vhdlcompargs'):
+            self._vhdlcompargs = []
+        return self._vhdlcompargs
+    @vhdlcompargs.setter
+    def vhdlcompargs(self, value):
+        self._vhdlcompargs = value
+
+    @property
     def vhdlentityfiles(self):
         '''List of VHDL entity files to be compiled in addition to DUT
 


### PR DESCRIPTION
- Adds a routine to copy additional VHDL sources for sv models
- Adds the command for compiling additional VHDL sources for sv models
- Adds a new property, vhdlcompargs, i.e. VHDL compilation arguments
  - e.g. `self.vhdlcompargs = ["-2008"]`
- Bugfix: make RTL simulation run locally for interactive runs

Tested with inverter and a certain another project that runs Verilog top with additional VHDL source files.