### PR TITLE
Add timescale statement to verilog testbench

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -116,6 +116,22 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             self._rtl_timescale = val
 
     @property
+    def add_tb_timescale(self):
+        """Bool : Defines if timescale directive is added to testbench. Can
+        be used in cases where submodules have timescale directives, and 
+        you wish to control that from the testbench toplevel. Effective only for 
+        elf.lang = 'sv'
+
+        Default: False
+        """
+        if not hasattr(self,'_add_tb_timescale'):
+            self._add_tb_timescale = False
+        return self._add_tb_timescale
+    @add_tb_timescale.setter
+    def add_tb_timescale(self,val):
+        self._add_tb_timescale = val 
+        
+    @property
     def name(self):
         ''' Name of the entity
             Extracted from the _classfile attribute

--- a/rtl/sv/verilog_module.py
+++ b/rtl/sv/verilog_module.py
@@ -371,7 +371,7 @@ class verilog_module(module_common,thesdk):
         if not os.path.isfile(self.file):
             self.print_log(msg='Exporting verilog_module to %s.' %(self.file))
             with open(self.file, "w") as module_file:
-                module_file.write(self.definition)
+                module_file.write(self.header+self.definition)
 
         elif os.path.isfile(self.file) and not kwargs.get('force'):
             self.print_log(type='F', msg=('Export target file %s exists.\n Force overwrite with force=True.' %(self.file)))

--- a/rtl/sv/verilog_testbench.py
+++ b/rtl/sv/verilog_testbench.py
@@ -32,7 +32,31 @@ class verilog_testbench(testbench_common):
         
         """
         super().__init__(parent,**kwargs)
-        self.header='`timescale ' + self.rtl_timescale + ' / '+ self.rtl_timescale+'\n'
+        if self.parent.add_tb_timescale:
+            self.header='`timescale ' + self.rtl_timescale + ' / '+ self.rtl_timescale+'\n'
+        else:
+            self.header=''
+
+    # For some reason unknown to me, overloading he property here is not effective
+    #@property
+    #def header(self):
+    #    """ str : Header line of the verilog testbench file.
+    #    Default: If self.add_tb_timescale = True, adds the timescale directive to the testbench top.
+    #    according ot self.rtl_timescale attribute.   
+    #    """
+    #    
+    #    if not hasattr (self, '_header'):
+    #        if self.parent.add_tb_timescale:
+    #            self._defheader='`timescale ' + self.rtl_timescale + ' / '+ self.rtl_timescale+'\n'
+    #        else:
+    #            self._defheader=''
+    #        return self._defheader    
+    #    else:
+    #        return self._header
+
+    #@header.setter
+    #def header(self,val):
+    #    self._header = val
         
     @property
     def parameter_definitions(self):

--- a/rtl/sv/verilog_testbench.py
+++ b/rtl/sv/verilog_testbench.py
@@ -32,7 +32,7 @@ class verilog_testbench(testbench_common):
         
         """
         super().__init__(parent,**kwargs)
-        self.header=''
+        self.header='`timescale ' + self.rtl_timescale + ' / '+ self.rtl_timescale+'\n'
         
     @property
     def parameter_definitions(self):

--- a/rtl/testbench.py
+++ b/rtl/testbench.py
@@ -241,7 +241,6 @@ class testbench(testbench_common):
         IO definitions.
 
         Overloads the property inherited from 'module', as wish to control whan we generate the headers.
-        [TO BE RECONSIDERED]
         '''
         self._definition=self.langmodule.header+self.langmodule.definition
         return self._definition

--- a/rtl/testbench_common.py
+++ b/rtl/testbench_common.py
@@ -46,12 +46,7 @@ class testbench_common(module):
 
     @property
     def rtl_timescale(self):
-        if not hasattr(self,'_lang'):
-            self._lang=self.parent.lang
-        return self._lang
-    @rtl_timescale.setter
-    def lang(self,val):
-        self._lang = val
+        return self.parent.rtl_timescale
 
     @property
     def lang(self):

--- a/rtl/vhdl/vhdl_testbench.py
+++ b/rtl/vhdl/vhdl_testbench.py
@@ -34,6 +34,24 @@ class vhdl_testbench(testbench_common):
         super().__init__(parent,**kwargs)
         self.header="""library ieee;\nuse ieee.std_logic_1164.all;\nuse ieee.numeric_std.all;\nuse std.textio.all;\n\n"""
 
+    # For some reason unknown to me, overloading he property here is not effective
+    #@property
+    #def header(self):
+    #    """ str : Header line of the VHDL testbench file.
+    #    Default: 
+    #        library ieee;
+    #        use ieee.std_logic_1164.all;
+    #        use ieee.numeric_std.all;
+    #        use std.textio.all;
+
+    #    """
+    #    
+    #    if not hasattr (self, '_header'):
+    #        self._header="""library ieee;\nuse ieee.std_logic_1164.all;\nuse ieee.numeric_std.all;\nuse std.textio.all;\n\n"""
+    #    return self._header
+    #@header.setter
+    #def header(self,val):
+    #    self._header = val
         
     @property
     def parameter_definitions(self):


### PR DESCRIPTION
Added `timescale directive to the verilog testbench. This setting corresponds the values set by commnad line arguments, i.e time is presented as integers of the time resolution.

I am not very confident that this is mandatory or desired feature.