### PR TITLE
Verilog connector signal type defaults to None

### DIFF
--- a/rtl/sv/verilog_connector.py
+++ b/rtl/sv/verilog_connector.py
@@ -27,23 +27,27 @@ class verilog_connector(connector_common,thesdk):
 
     @property
     def type(self):
+        ''' Type defaults to None mening that all signals are handled as unsigned integers.
+        Can be explicitly set to 'signed' if needed.
+        '''
+
         # We must handle parametrized widths
         if not hasattr(self, '_type'):
             if type(self.width) == str:
-                self._type = 'signed'
+                self._type = None
             elif self.width == 1:
                 self._type = None
             elif self.width > 1:
-                self._type = 'signed'
+                self._type = None
         else:
             if type(self.width) == str and self._type != 'signed':
-                self.print_log(type='I', msg='Setting type \'%s\' to type \'signed\' due to parametrized width ' %(self._type))
-                self._type = 'signed'
+                self.print_log(type='I', msg='Setting type \'%s\' to type None due to parametrized width ' %(self._type))
+                self._type = None
             elif self.width == 1 and self._type != 'signed':
-                pass
+                self._type = None
             elif self.width > 1 and self._type != 'signed':
-                self.print_log(type='I', msg='Setting type \'%s\' of signal \'%s\' to type \'signed\'' %(self._type,self.name))
-                self._type = 'signed'
+                self.print_log(type='I', msg='Setting type \'%s\' of signal \'%s\' to type None' %(self._type,self.name))
+                self._type = None
         return self._type
     @type.setter
     def type(self,value):

--- a/rtl/testbench.py
+++ b/rtl/testbench.py
@@ -243,6 +243,7 @@ class testbench(testbench_common):
         Overloads the property inherited from 'module', as wish to control whan we generate the headers.
         [TO BE RECONSIDERED]
         '''
+        pdb.set_trace()
         self._definition=self.langmodule.header+self.langmodule.definition
         return self._definition
 

--- a/rtl/vhdl/vhdl_connector.py
+++ b/rtl/vhdl/vhdl_connector.py
@@ -25,13 +25,14 @@ class vhdl_connector(connector_common,thesdk):
         self._type=kwargs.get('type', 'std_logic_vector' ) # Depends on language
     @property
     def type(self):
+        ''' Type defaults to std_logic_vector meaning that all signals are handled as unsigned integers.
+        '''
         if not hasattr(self, '_type'):
             if type(self.width) == str:
                 self._type = 'std_logic_vector'
             elif self.width == 1:
                 self._type = 'std_logic'
             elif self.width > 1:
-                self._type = 'signed'
                 self._type = 'std_logic_vector'
         else:
             if self.width == 1 and self._type != 'std_logic':


### PR DESCRIPTION
Defaulting to 'signed' was a big mistake causing lot's of problems.