### PR TITLE
Iosync

### DIFF
--- a/rtl/rtl_iofile.py
+++ b/rtl/rtl_iofile.py
@@ -357,16 +357,28 @@ class rtl_iofile(verilog_iofile_obsoletes,rtl_iofile_common):
         self.langmodule.rtl_io_condition_append(**kwargs)
 
     @property 
-    def rtl_io_sync(self):
-        '''File io synchronization condition for sample type input.
+    def rtl_input_sync(self):
+        '''File input synchronization condition for sample type input.
         Default: `@(posedge clock)`
 
         '''
-        return self.langmodule.rtl_io_sync
+        return self.langmodule.rtl_input_sync
 
-    @rtl_io_sync.setter
-    def rtl_io_sync(self,value):
-        self.langmodule.rtl_io_sync=value
+    @rtl_input_sync.setter
+    def rtl_input_sync(self,value):
+        self.langmodule.rtl_input_sync=value
+
+    @property 
+    def rtl_output_sync(self):
+        '''File output synchronization condition for sample type output.
+        Default: `@(posedge clock)`
+
+        '''
+        return self.langmodule.rtl_output_sync
+
+    @rtl_output_sync.setter
+    def rtl_output_sync(self,value):
+        self.langmodule.rtl_output_sync=value
 
     def rtl_io_condition_append(self,**kwargs ):
         '''Append new condition string to `rtl_io_condition`

--- a/rtl/sv/verilog_iofile.py
+++ b/rtl/sv/verilog_iofile.py
@@ -185,20 +185,37 @@ class verilog_iofile(rtl_iofile_common):
         self._rtl_io_condition=value
 
     @property 
-    def rtl_io_sync(self):
-        '''File io synchronization condition for sample type input.
+    def rtl_input_sync(self):
+        '''File input synchronization condition for sample type input.
         Default: `@(posedge clock)`
 
         '''
 
-        if not hasattr(self,'_rtl_io_sync'):
+        if not hasattr(self,'_rtl_input_sync'):
             if self.iotype=='sample':
-                self._rtl_io_sync= '@(posedge clock)\n'
-        return self._rtl_io_sync
+                self._rtl_input_sync= '@(posedge clock)\n'
+        return self._rtl_input_sync
 
-    @rtl_io_sync.setter
-    def rtl_io_sync(self,value):
-        self._rtl_io_sync=value
+    @rtl_input_sync.setter
+    def rtl_input_sync(self,value):
+        self._rtl_input_sync=value
+
+    @property 
+    def rtl_output_sync(self):
+        '''File output synchronization condition for sample type output.
+        Default: `@(posedge clock)`
+
+        '''
+
+        if not hasattr(self,'_rtl_output_sync'):
+            if self.iotype=='sample':
+                self._rtl_output_sync= '@(posedge clock)\n'
+        return self._rtl_output_sync
+
+    @rtl_output_sync.setter
+    def rtl_output_sync(self,value):
+        self._rtl_output_sync=value
+
 
     def rtl_io_condition_append(self,**kwargs ):
         '''Append new condition string to `rtl_io_condition`
@@ -228,12 +245,12 @@ class verilog_iofile(rtl_iofile_common):
         first=True
         if self.parent.iotype=='sample':
             if self.parent.dir=='out':
-                self._rtl_io='always '+self.rtl_io_sync +'begin\n'
+                self._rtl_io='always '+ self.rtl_output_sync +'begin\n'
                 self._rtl_io+=indent(text='if ( %s ) begin\n' %(self.rtl_io_condition), level=1)
                 self._rtl_io+=indent(text='$fwrite(%s, ' %(self.rtl_fptr), level=2)
             elif self.parent.dir=='in':
                 self._rtl_io='while (!$feof(f_%s)) begin\n' %self.name
-                self._rtl_io+=indent(text='%s' %self.rtl_io_sync, level=0)
+                self._rtl_io+=indent(text='%s' %self.rtl_input_sync, level=0)
                 self._rtl_io+=indent(text='if ( %s ) begin\n' %self.rtl_io_condition, level=1)
                 self._rtl_io+=indent(text='%s = $fscanf(%s, ' \
                         %(self.rtl_stat, self.rtl_fptr), level=2)


### PR DESCRIPTION
Currently syncing IOs with different input and output clock frequencies isn't possible (that I'm aware of), this is easily fixable by splitting rtl_io_sync to rtl_input_sync and rtl_output_sync respectively. 