### PR TITLE
Timescale propagation

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 from functools import reduce
 import shutil
+import re
 
 from rtl.connector import indent, rtl_connector_bundle, verilog_connector_bundle
 from rtl.testbench import testbench as vtb
@@ -39,6 +40,7 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
 
     def __init__(self):
         pass
+
 
     @property
     def lang(self):
@@ -113,8 +115,46 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             self._rtl_timescale = '1ps'
         return self._rtl_timescale
     @rtl_timescale.setter
-    def rtl_timescale(self,val):
-            self._rtl_timescale = val
+    def rtl_timescale(self, val):
+        self._rtl_timescale = val
+
+    @property
+    def rtl_timescale_num(self):
+        val = self.rtl_timescale
+        match = re.match(r'(\d+)(\D+)', val.replace(" ",""))
+        if match:
+            number = int(match.group(1))
+            text = match.group(2)
+        else:
+            self.print_log(type='F', msg=f"Invalid rtl_timescale string: {val}. Allowed e.g. 1ps")
+        if text == "s": pass
+        elif text == "ms": number *= 1e-3
+        elif text == "us": number *= 1e-6
+        elif text == "ns": number *= 1e-9
+        elif text == "ps": number *= 1e-12
+        elif text == "fs": number *= 1e-15
+        else:
+            self.print_log(type='F', msg=f"Invalid rtl_timescale unit: {val}. Allowed s,ms,us,ns,ps,fs")
+        return number
+
+    @property
+    def rtl_timeprecision_num(self):
+        val = self.rtl_timescale
+        match = re.match(r'(\d+)(\D+)', val.replace(" ",""))
+        if match:
+            number = int(match.group(1))
+            text = match.group(2)
+        else:
+            self.print_log(type='F', msg=f"Invalid rtl_timeprecision string: {val}. Allowed e.g. 1ps")
+        if text == "s": pass
+        elif text == "ms": number *= 1e-3
+        elif text == "us": number *= 1e-6
+        elif text == "ns": number *= 1e-9
+        elif text == "ps": number *= 1e-12
+        elif text == "fs": number *= 1e-15
+        else:
+            self.print_log(type='F', msg=f"Invalid rtl_timeprecision unit: {val}. Allowed s,ms,us,ns,ps,fs")
+        return number
 
     @property
     def rtl_timeunit(self):

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -107,7 +107,7 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
     @property
     def rtl_timescale(self):
         """
-        Defines the rtl timescal. This is the time unit shown by the simulator
+        Defines the rtl timescale. This is the time unit shown by the simulator
         and used in testbench delays. Default '1ps'
 
         """
@@ -120,6 +120,10 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
 
     @property
     def rtl_timescale_num(self):
+        """
+        Returns rtl_timescale as a floating point number. Determined from rtl_timescale.
+        No setter.
+        """
         val = self.rtl_timescale
         match = re.match(r'(\d+)(\D+)', val.replace(" ",""))
         if match:
@@ -127,18 +131,21 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             text = match.group(2)
         else:
             self.print_log(type='F', msg=f"Invalid rtl_timescale string: {val}. Allowed e.g. 1ps")
-        if text == "s": pass
-        elif text == "ms": number *= 1e-3
+        if text == "ms": number *= 1e-3
         elif text == "us": number *= 1e-6
         elif text == "ns": number *= 1e-9
         elif text == "ps": number *= 1e-12
         elif text == "fs": number *= 1e-15
         else:
-            self.print_log(type='F', msg=f"Invalid rtl_timescale unit: {val}. Allowed s,ms,us,ns,ps,fs")
+            self.print_log(type='F', msg=f"Invalid rtl_timescale unit: {val}. Allowed ms,us,ns,ps,fs")
         return number
 
     @property
     def rtl_timeprecision_num(self):
+        """
+        Returns rtl_timeprecision as a floating point number. Determined from rtl_timeprecision.
+        No setter.
+        """
         val = self.rtl_timescale
         match = re.match(r'(\d+)(\D+)', val.replace(" ",""))
         if match:
@@ -146,14 +153,13 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             text = match.group(2)
         else:
             self.print_log(type='F', msg=f"Invalid rtl_timeprecision string: {val}. Allowed e.g. 1ps")
-        if text == "s": pass
-        elif text == "ms": number *= 1e-3
+        if text == "ms": number *= 1e-3
         elif text == "us": number *= 1e-6
         elif text == "ns": number *= 1e-9
         elif text == "ps": number *= 1e-12
         elif text == "fs": number *= 1e-15
         else:
-            self.print_log(type='F', msg=f"Invalid rtl_timeprecision unit: {val}. Allowed s,ms,us,ns,ps,fs")
+            self.print_log(type='F', msg=f"Invalid rtl_timeprecision unit: {val}. Allowed ms,us,ns,ps,fs")
         return number
 
     @property

--- a/rtl/sv/verilog_testbench.py
+++ b/rtl/sv/verilog_testbench.py
@@ -83,7 +83,7 @@ class verilog_testbench(testbench_common):
 
         """
         if not hasattr(self,'_content_parameters'):
-            self._content_parameters={'c_Ts': ('integer','1/(g_Rs*1e-12)')} 
+            self._content_parameters={'c_Ts': ('integer',f'1/(g_Rs*{self.rtl_timescale_num})')} 
         return self._content_parameters
     @content_parameters.setter    
     def content_parameters(self,val):

--- a/rtl/testbench_common.py
+++ b/rtl/testbench_common.py
@@ -53,6 +53,14 @@ class testbench_common(module):
         return self.parent.rtl_timeprecision
 
     @property
+    def rtl_timescale_num(self):
+        return self.parent.rtl_timescale_num
+
+    @property
+    def rtl_timeprecision_num(self):
+        return self.parent.rtl_timeprecision_num
+
+    @property
     def lang(self):
         if not hasattr(self,'_lang'):
             self._lang=self.parent.lang

--- a/rtl/vhdl/vhdl_testbench.py
+++ b/rtl/vhdl/vhdl_testbench.py
@@ -80,7 +80,10 @@ class vhdl_testbench(testbench_common):
 
         """
         if not hasattr(self,'_content_parameters'):
-            self._content_parameters={'c_Ts': ('time','1.0/(g_Rs*1.0e-12)*1.0 ps')} 
+            # Unit is always two characters
+            stripped = self.rtl_timescale.strip()
+            unit = stripped[-2] + stripped[-1]
+            self._content_parameters={'c_Ts': ('time',f'1.0/(g_Rs*{self.rtl_timescale_num:.1e})*1.0 {unit}')} 
         return self._content_parameters
     @content_parameters.setter    
     def content_parameters(self,val):


### PR DESCRIPTION
Clock period did not take into account the ability to set rtl_timescale. This is fixed.

Adds two new properties, `rtl_timescale_num` and `rtl_timeprecision_num`, which return the timescale and -precision as a floating point number.

The timescale should be added in a format `<num><unit>`, for example `1ns`. The number can be an arbitrary integer, i.e. 10, 100, or even 33 is supported as well. Unit can be from the set `ms,us,ns,ps,fs`.