### PR TITLE
Questa optimization presets

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -192,6 +192,10 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
 
     @property
     def sim_opt_dict(self):
+        '''Preset dictionary for running optimization on the simulation.
+        The actual dictionary should be implemented in the simulator class.
+        Returns an empty dictionary for classes which have not implemented it.
+        '''
         if not hasattr(self, '_sim_opt_dict'):
             if self.model == 'sv':
                 self._sim_opt_dict = self.questasim_sim_opt_dict
@@ -206,6 +210,10 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
 
     @property
     def sim_optimization(self):
+        '''Simulation optimization option. The value in this property
+        is used to fetch the simulator-specific simulation argument from
+        sim_opt_dict. By default, returns 'default' if the target sim_opt_dict
+        contains a value with that key, and None otherwise.'''
         if not hasattr(self, '_sim_optimization'):
             if 'default' in self.sim_opt_dict.keys():
                 self._sim_optimization = 'default'

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -222,13 +222,14 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         Default: 'opt-visible' for non-interactive simulations, 'no-opt'
         for interactive simulations.
         Set to 'None' is you wish to set self.vlogsimargs manually.
+
         '''
 
         if not hasattr(self, '_sim_optimization'):
-            if [ not self.interactive_rtl ]:
+            if not self.interactive_rtl:
                 self._sim_optimization = 'opt-visible'
             else:
-                self._sim_optimization = 'opt-visible'
+                self._sim_optimization = 'no-opt'
 
         return self._sim_optimization
     @sim_optimization.setter

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -190,6 +190,35 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
     def rtl_timeprecision(self, val):
         self._rtl_timeprecision = val
 
+    @property
+    def sim_opt_dict(self):
+        if not hasattr(self, '_sim_opt_dict'):
+            if self.model == 'sv':
+                self._sim_opt_dict = self.questasim_sim_opt_dict
+            elif self.model == 'vhdl':
+                self._sim_opt_dict = self.questasim_sim_opt_dict
+            else:
+                self._sim_optimization = {}
+        return self._sim_optimization
+    @sim_opt_dict.setter
+    def sim_opt_dict(self, value):
+        self._sim_opt_dict = value
+
+    @property
+    def sim_optimization(self):
+        if not hasattr(self, '_sim_optimization'):
+            if 'default' in self.sim_opt_dict.keys():
+                self._sim_optimization = 'default'
+            else:
+                self._sim_optimization = None
+    @sim_optimization.setter
+    def sim_optimization(self, value):
+        if value in self.sim_opt_dict.keys():
+            self._sim_optimization = value
+        else:
+            self.print_log(type='F', msg=(
+                f'Key not found in sim_opt_dict: {value}.'
+                f'Available keys: {self.sim_opt_dict.keys()}'))
 
     @property
     def add_tb_timescale(self):
@@ -825,6 +854,9 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                     os.remove(file.name)
                 except:
                     pass
+
+        if self.sim_optimization:
+            self.vlogsimargs += self.sim_opt_dict[self.sim_optimization]
 
         self.print_log(type='I', msg="Running external command %s\n" %(self.rtlcmd) )
 

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -198,8 +198,8 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             elif self.model == 'vhdl':
                 self._sim_opt_dict = self.questasim_sim_opt_dict
             else:
-                self._sim_optimization = {}
-        return self._sim_optimization
+                self._sim_opt_dict = {}
+        return self._sim_opt_dict
     @sim_opt_dict.setter
     def sim_opt_dict(self, value):
         self._sim_opt_dict = value
@@ -211,13 +211,14 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                 self._sim_optimization = 'default'
             else:
                 self._sim_optimization = None
+        return self._sim_optimization
     @sim_optimization.setter
     def sim_optimization(self, value):
         if value in self.sim_opt_dict.keys():
             self._sim_optimization = value
         else:
             self.print_log(type='F', msg=(
-                f'Key not found in sim_opt_dict: {value}.'
+                f'Key not found in sim_opt_dict: {value}. '
                 f'Available keys: {self.sim_opt_dict.keys()}'))
 
     @property

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -881,9 +881,6 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                 except:
                     pass
 
-        if self.sim_optimization:
-            self.vlogsimargs += self.sim_opt_dict[self.sim_optimization]
-
         self.print_log(type='I', msg="Running external command %s\n" %(self.rtlcmd) )
 
         if self.interactive_rtl:

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -193,14 +193,12 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
     @property
     def sim_opt_dict(self):
         '''Preset abstraction dictionary for running optimization on the simulation.
-        The actual dictionary is implemented in the simulator class.  Always returns
-        default value for simulators that do not .
+        The actual dictionary is implemented in the simulator class.  Returns
+        Dict with empty strings for simulators that do not use this property'
         Valid values:
         - 'no-opt' - no optimizations, full visibility to signals
         - 'opt-visible' - optimized with full visibility.
         - 'full-opt' - fully optimized, might lose visibility to a lot of signals. Simulation may not work.
-        - 'default' - not optimized simulation for interactive sims, optimized with full visibility for
-        non-interactive sims
         - 'top-visible' - optimized while keeping top level (testbench) signals.
         - 'top-dut-visible' - optimized while keeping top level (testbench) and DUT signals on the first
         hierarchy level
@@ -211,7 +209,14 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             elif self.model == 'vhdl':
                 self._sim_opt_dict = self.questasim_sim_opt_dict
             else:
-                self._sim_opt_dict = {}
+                self._sim_opt_dict = { 
+                        'no-opt' : '',
+                        'opt-visible' : '',
+                        'full-opt' : '',
+                        'top-visible' : '',
+                        'top-dut-visible' : ''
+                        }
+
         return self._sim_opt_dict
 
     @property
@@ -234,7 +239,7 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         return self._sim_optimization
     @sim_optimization.setter
     def sim_optimization(self, value):
-        if value in self.sim_opt_dict.keys():
+        if value in [ self.sim_opt_dict.keys(), None ]:
             self._sim_optimization = value
         else:
             self.print_log(type='F', msg=(

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -239,7 +239,7 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         return self._sim_optimization
     @sim_optimization.setter
     def sim_optimization(self, value):
-        if value in [ self.sim_opt_dict.keys(), None ]:
+        if value in list(self.sim_opt_dict.keys()) + [None ]:
             self._sim_optimization = value
         else:
             self.print_log(type='F', msg=(

--- a/rtl/questasim/questasim.py
+++ b/rtl/questasim/questasim.py
@@ -6,6 +6,33 @@ Initially written by Marko kosunen 20221030
 """
 from thesdk import *
 class questasim(thesdk):
+
+    @property
+    def sim_optimization(self):
+        '''Presets for running optimization on the simulation.
+
+        - 'none' - use this if you want to manually control vopt related flags with vlogsimargs
+        - 'default' - not optimized simulation for interactive sims,
+        optimized with full visibility for non-interactive sims
+        - 'no-opt' - no optimizations, full visibility to signals
+        - 'full-opt' - fully optimized, might lose visibility to a lot of signals. Simulation may not work.
+        - 'top-visible' - optimized while keeping top level (testbench) signals.
+        - 'top-dut-visible' - optimized while keeping top level (testbench) and DUT signals on the first hierarchy level    
+        '''
+        if not hasattr(self, '_sim_optimization'):
+            self._sim_optimization = 'default'
+        return self._sim_optimization
+    @sim_optimization.setter
+    def sim_optimization(self, value):
+        if value not in ['none',
+                         'default',
+                         'no-opt',
+                         'full-opt',
+                         'top-visible',
+                         'top-dut-visible']:
+            self.print_log(type="E", msg=f"Unsupported optimization type: {value}")
+        self._sim_optimization = value
+
     @property
     def questasim_rtlcmd(self):
         submission=self.lsf_submission
@@ -70,6 +97,25 @@ class questasim(thesdk):
                                 ('-g ' + str(param) +'='+ str(val[1])) 
                                 for param,val in self.rtlparameters.items() 
                             ])
+
+        if self.sim_optimization == 'default':
+            self.print_log(type='I', msg=("Running simulation with default optimization settings."
+                           "Simulation may be slow. Check sim_optimization property."))
+            if self.interactive_rtl:
+                self.vlogsimargs += ['-novopt']
+            else:
+                self.vlogsimargs += ['-voptargs=+acc']
+        elif self.sim_optimization == 'no-opt':
+            self.vlogsimargs += ['-novopt']
+        elif self.sim_optimization == 'full-opt':
+            self.vlogsimargs += ['-vopt']
+        elif self.sim_optimization == 'top-visible':
+            self.vlogsimargs += ['-vopt', f'-voptargs="+acc=bcglnprst+tb_{self.name}"']
+        elif self.sim_optimization == 'top-dut-visible':
+            self.vlogsimargs += \
+                ['-vopt', f'-voptargs="+acc=bcglnprst+tb_{self.name} +acc=bcglnprst+{self.name}"']
+
+
         vlogsimargs = ' '.join(self.vlogsimargs)
 
         fileparams=''
@@ -94,13 +140,13 @@ class questasim(thesdk):
 
         # Choose command 
         if not self.interactive_rtl:
-            rtlsimcmd = ( 'vsim -64 -batch' + timescalestring + ' -voptargs=+acc ' 
+            rtlsimcmd = ( 'vsim -64 -batch' + timescalestring 
                     + fileparams + ' ' + gstring
                     + ' ' + vlogsimargs + ' work.tb_' + self.name  
                     + controlstring)
         else:
             submission="" #Local execution
-            rtlsimcmd = ( 'vsim -64 ' + timescalestring + ' -novopt ' + fileparams 
+            rtlsimcmd = ( 'vsim -64 ' + timescalestring + fileparams 
                     + ' ' + gstring + ' ' + vlogsimargs + ' work.tb_' + self.name 
                          + interactive_string )
 

--- a/rtl/questasim/questasim.py
+++ b/rtl/questasim/questasim.py
@@ -13,6 +13,8 @@ class questasim(thesdk):
 
         - 'no-opt' - no optimizations, full visibility to signals
         - 'full-opt' - fully optimized, might lose visibility to a lot of signals. Simulation may not work.
+        - 'default' - not optimized simulation for interactive sims,
+        optimized with full visibility for non-interactive sims
         - 'top-visible' - optimized while keeping top level (testbench) signals.
         - 'top-dut-visible' - optimized while keeping top level (testbench) and DUT signals on the first hierarchy level    
         '''

--- a/rtl/sv/sv.py
+++ b/rtl/sv/sv.py
@@ -105,6 +105,9 @@ class sv(thesdk,metaclass=abc.ABCMeta):
         return self._verilog_sim_args
     @vlogsimargs.setter
     def vlogsimargs(self, simparam):
+        # This might be needed
+        #_ = self.vlogsimargs
+        self.sim_optimization= None
         self._verilog_sim_args = simparam
 
     def sv_create_connectors(self):

--- a/rtl/sv/sv.py
+++ b/rtl/sv/sv.py
@@ -6,7 +6,7 @@ System verilog class
 This mixin class contains all system verilog and verilog related properties that
 are used by simulator specific classes.
 
-Initially written by Marko Kosunen 30.10.20200, marko.kosunen@aalto.fi 
+Initially written by Marko Kosunen 30.10.20200, marko.kosunen@aalto.fi
 """
 
 
@@ -86,27 +86,30 @@ class sv(thesdk,metaclass=abc.ABCMeta):
             self._vlogmodulefiles =list([])
         return self._vlogmodulefiles
     @vlogmodulefiles.setter
-    def vlogmodulefiles(self,value): 
+    def vlogmodulefiles(self,value):
             self._vlogmodulefiles = value
     @vlogmodulefiles.deleter
-    def vlogmodulefiles(self): 
-            self._vlogmodulefiles = None 
+    def vlogmodulefiles(self):
+            self._vlogmodulefiles = None
 
     @property
     def vlogsimargs(self):
         '''Custom parameters for verilog simulation
         Provide as a list of strings
         '''
-        if not hasattr(self, '_verilog_sim_args'):
-            self._verilog_sim_args = []
+        if self.sim_optimization:
+            self._verilog_sim_args = self.sim_opt_dict[self.sim_optimization]
+        else:
+            if not hasattr(self,'_verilog_sim_args'):
+                self._verilog_sim_args = []
         return self._verilog_sim_args
     @vlogsimargs.setter
     def vlogsimargs(self, simparam):
         self._verilog_sim_args = simparam
 
     def sv_create_connectors(self):
-        '''Cretes verilog connector definitions from 
-           1) From a iofile that is provided in the Data 
+        '''Cretes verilog connector definitions from
+           1) From a iofile that is provided in the Data
            attribute of an IO.
            2) IOS of the verilog DUT
 
@@ -115,9 +118,9 @@ class sv(thesdk,metaclass=abc.ABCMeta):
         # See controller.py
         for ioname,io in self.IOS.Members.items():
             # If input is a file, adopt it
-            if isinstance(io.Data,rtl_iofile): 
+            if isinstance(io.Data,rtl_iofile):
                 if io.Data.name is not ioname:
-                    self.print_log(type='I', 
+                    self.print_log(type='I',
                             msg='Unifying file %s name to ioname %s' %(io.Data.name,ioname))
                     io.Data.name=ioname
                 io.Data.adopt(parent=self)
@@ -126,7 +129,7 @@ class sv(thesdk,metaclass=abc.ABCMeta):
                 for connector in io.Data.rtl_connectors:
                     self.tb.connectors.Members[connector.name]=connector
                     # Connect them to DUT
-                    try: 
+                    try:
                         self.dut.ios.Members[connector.name].connect=connector
                     except:
                         pass
@@ -136,13 +139,13 @@ class sv(thesdk,metaclass=abc.ABCMeta):
                 for name in val.ionames:
                     # [TODO] Sanity check, only floating inputs make sense.
                     if not name in self.tb.connectors.Members.keys():
-                        self.print_log(type='I', 
+                        self.print_log(type='I',
                                 msg='Creating non-existent IO connector %s for testbench' %(name))
                         self.tb.connectors.new(name=name, cls='reg')
                 self.iofile_bundle.Members[ioname].rtl_connectors=\
                         self.tb.connectors.list(names=val.ionames)
                 self.tb.parameters.Members.update(val.rtlparam)
         # Define the iofiles of the testbench. '
-        # Needed for creating file io routines 
+        # Needed for creating file io routines
         self.tb.iofiles=self.iofile_bundle
 


### PR DESCRIPTION
This PR adds a property `sim_optimization` and `sim_opt_dict` to `rtl` class. They provides predefined preset options for running an optimized design. Using optimization speeds up the simulation a lot.

The presets are:
- 'no-opt' - no optimizations, full visibility to signals
- 'opt-visible' - optimized with full visibility.
- 'full-opt' - fully optimized, might lose visibility to a lot of signals. Simulation may not work.
- 'top-visible' - optimized while keeping top level (testbench) signals.
- 'top-dut-visible' - optimized while keeping top level (testbench) and DUT signals on the first hierarchy level

These optimizations work only for questa for the moment