### PR TITLE
Property `rtlfiles` to replace `vlogmodulefiles` and `vhdlentityfiles`

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -431,7 +431,10 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
 
         '''
         if not hasattr(self, '_vlogmodulefiles'):
-            self._vlogmodulefiles =list([])
+            self._vlogmodulefiles = []
+            for module in self.rtlfiles:
+                if os.path.splitext(module)[1] in [".sv", ".v"]:
+                    self._vlogmodulefiles += [module]
         return self._vlogmodulefiles
     @vlogmodulefiles.setter
     def vlogmodulefiles(self,value):
@@ -494,7 +497,10 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
 
         '''
         if not hasattr(self, '_vhdlentityfiles'):
-            self._vhdlentityfiles =list([])
+            self._vhdlentityfiles = []
+            for module in self.rtlfiles:
+                if os.path.splitext(module)[1] in [".vhd", ".vhdl"]:
+                    self._vhdlentityfiles += [module]
         return self._vhdlentityfiles
     @vhdlentityfiles.setter
     def vhdlentityfiles(self,value):
@@ -803,6 +809,7 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         tb_bname = os.path.basename(self.simtb)
 
         # Merge all different modules to one
+        # This also maintains backward compatibility
         self.rtlfiles += self.vloglibfilemodules + self.vlogmodulefiles + \
                             self.vhdllibfileentities + self.vhdlentityfiles
 

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -644,6 +644,19 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
     def rtlcmd(self):
         self._rtlcmd=None
 
+    @property
+    def compile_order(self):
+        """Set manual compile order. The value should be a 2D list, where one entry contains a list
+        of modules to be compiled together. Only file name, no path.
+        """
+        if not hasattr(self, '_compile_order'):
+            self._compile_order = []
+        return self._compile_order
+
+    @compile_order.setter
+    def compile_order(self, order):
+        self._compile_order = order
+
     def create_connectors(self):
         '''Creates connector definitions from
            1) From a iofile that is provided in the Data

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -435,10 +435,13 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         return self._vlogmodulefiles
     @vlogmodulefiles.setter
     def vlogmodulefiles(self,value):
-            self._vlogmodulefiles = value
+        self.print_log(type='O', msg=(
+            'Use rtlfiles for both VHDL and Verilog files instead of vlogmodulefiles.')
+        )
+        self._vlogmodulefiles = value
     @vlogmodulefiles.deleter
     def vlogmodulefiles(self):
-            self._vlogmodulefiles = None
+        self._vlogmodulefiles = None
 
     @property
     def vloglibfilemodules(self):
@@ -473,6 +476,19 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             self._vloglibfilemodules = None
 
     @property
+    def rtlfiles(self):
+        '''List of VHDL and Verilog files to be compiled.
+        File suffices should be '.vhd', '.vhdl', '.sv', or '.v'.
+        Order determines compile order.
+        '''
+        if not hasattr(self, '_rtlfiles'):
+            self._rtlfiles = []
+        return self._rtlfiles
+    @rtlfiles.setter
+    def rtlfiles(self, value):
+        self._rtlfiles = value
+
+    @property
     def vhdlentityfiles(self):
         '''List of VHDL entity files to be compiled in addition to DUT
 
@@ -482,10 +498,13 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         return self._vhdlentityfiles
     @vhdlentityfiles.setter
     def vhdlentityfiles(self,value):
-            self._vhdlentityfiles = value
+        self.print_log(type='O', msg=(
+            'Use rtlfiles for both VHDL and Verilog files instead of vhdlentityfiles.')
+        )
+        self._vhdlentityfiles = value
     @vhdlentityfiles.deleter
     def vhdlentityfiles(self):
-            self._vhdlentityfiles = None
+        self._vhdlentityfiles = None
     @property
     def vhdllibfileentities(self):
         '''List of VHDL entities to be compiled in addition to DUT
@@ -699,19 +718,6 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
     def rtlcmd(self):
         self._rtlcmd=None
 
-    @property
-    def compile_order(self):
-        """Set manual compile order. The value should be a 2D list, where one entry contains a list
-        of modules to be compiled together. Only file name, no path.
-        """
-        if not hasattr(self, '_compile_order'):
-            self._compile_order = []
-        return self._compile_order
-
-    @compile_order.setter
-    def compile_order(self, order):
-        self._compile_order = order
-
     def create_connectors(self):
         '''Creates connector definitions from
            1) From a iofile that is provided in the Data
@@ -782,85 +788,44 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         ''' Copy rtl sources to self.rtlsimpath
 
         '''
-        # I think these should not be model dependent MK
         self.print_log(type='I', msg='Copying rtl sources to %s' % self.rtlsimpath)
-        if self.model in ['sv', 'icarus']:
-            # copy dut source
-            vlogsrc_exists = os.path.isfile(self.vlogsrc)   # verilog source present in self.entitypath/sv
-            simdut_exists = os.path.isfile(self.simdut)     # verilog source generated to self.rtlsimpath
-            # if neither exist throw an fatal error (missing dut source)
-            if not vlogsrc_exists and not simdut_exists:
-                self.print_log(type='F', msg="Missing verilog source for 'sv' model at: %s" % self.vlogsrc)
-            # vlogsrc exists, simdut doesn't exist => copy vlogsrc to simdut
-            elif vlogsrc_exists and not simdut_exists:
-                self.print_log(type='I', msg='Copying %s to %s' % (self.vlogsrc, self.simdut))
-                self.copy_or_relink(src=self.vlogsrc,dst=self.simdut)
-            # vlogsrc doesn't exist, simdut exists (externally generated) => use externally generated simdut
-            elif not vlogsrc_exists and simdut_exists:
-                self.print_log(type='I', msg='Using externally generated source for DUT: %s' % self.simdut)
-            # if both sources are present throw a fatal error (multiple conflicting source files)
+
+        vlog_model = self.model in ['sv', 'icarus']
+        vhdl_model = self.model in ['ghdl', 'vhdl']
+
+        src = self.vlogsrc if vlog_model else self.vhdlsrc
+        # source generated to self.rtlsimpath
+        simdut_exists = os.path.isfile(self.simdut)
+        # source in static location (/sv/entity.sv or /vhdl/entity/vhd)
+        src_exists = os.path.isfile(src)
+        # Barename of DUT
+        dut_bname = os.path.basename(src)
+        tb_bname = os.path.basename(self.simtb)
+
+        # Merge all different modules to one
+        self.rtlfiles += self.vloglibfilemodules + self.vlogmodulefiles + \
+                            self.vhdllibfileentities + self.vhdlentityfiles
+
+        # Append dut to rtlfiles
+        if dut_bname not in self.rtlfiles:
+            self.rtlfiles += [dut_bname]
+
+        # Copy files if they exist under sv/ or vhdl/
+        for modfile in self.rtlfiles:
+            _, file_ext = os.path.splitext(modfile)
+            lang = "vlog" if file_ext in [".v", ".sv"] else "vhdl"
+            tgt_dir = self.vlogsrcpath if lang == "vlog" else self.vhdlsrcpath
+            srcfile = os.path.join(tgt_dir, modfile)
+            dstfile = os.path.join(self.rtlsimpath, modfile)
+            if os.path.isfile(dstfile):
+                self.print_log(type='I', msg='Using externally generated source: %s' % modfile)
             else:
-                self.print_log(type='W', msg="Both model 'sv' source %s and generated source %s exist. Using %s."
-                        % (self.vlogsrc, self.simdut, self.simdut))
+                self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
+                self.copy_or_relink(src=srcfile,dst=dstfile)
 
-            # copy other verilog files
-            for modfile in self.vlogmodulefiles+self.vloglibfilemodules:
-                srcfile = os.path.join(self.vlogsrcpath, modfile)
-                dstfile = os.path.join(self.rtlsimpath, modfile)
-                if os.path.isfile(dstfile):
-                    self.print_log(type='I', msg='Using externally generated source: %s' % modfile)
-                else:
-                    self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
-                    self.copy_or_relink(src=srcfile,dst=dstfile)
-
-            # copy additional VHDL files
-            for entfile in self.vhdlentityfiles:
-                srcfile = os.path.join(self.vhdlsrcpath, entfile)
-                dstfile = os.path.join(self.rtlsimpath, entfile)
-                if os.path.isfile(dstfile):
-                    self.print_log(type='I', msg='Using externally generated source: %s' % entfile)
-                else:
-                    self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
-                    self.copy_or_relink(src=srcfile,dst=dstfile)
-
-        # nothing generates vhdl so simply copy all files to rtlsimpath
-        elif self.model == 'vhdl' or self.model == 'ghdl':
-            vhdlsrc_exists = os.path.isfile(self.vhdlsrc)   # verilog source present in self.entitypath/sv
-            simdut_exists = os.path.isfile(self.simdut)     # verilog source generated to self.rtlsimpath
-
-            if not vhdlsrc_exists and not simdut_exists:
-                self.print_log(type='F', msg="Missing vhdl source for 'vhdl' model at: %s" % self.vlogsrc)
-            # vhdlsrc exists, simdut doesn't exist => copy vhdlsrc to simdut
-            elif vhdlsrc_exists and not simdut_exists:
-                self.print_log(type='I', msg='Copying %s to %s' % (self.vhdlsrc, self.simdut))
-                self.copy_or_relink(src=self.vhdlsrc,dst=self.simdut)
-            # vhdlsrc doesn't exist, simdut exists (externally generated) => use externally generated simdut
-            elif not vhdlsrc_exists and simdut_exists:
-                self.print_log(type='I', msg='Using externally generated source for DUT: %s' % self.simdut)
-            # if both sources are present throw a fatal error (multiple conflicting source files)
-            else:
-                self.print_log(type='W', msg="Both model 'sv' source %s and generated source %s exist. Using %s."
-                        % (self.vhdlsrc, self.simdut, self.simdut))
-
-            # copy other verilog files
-            for modfile in self.vlogmodulefiles:
-                srcfile = os.path.join(self.vlogsrcpath, modfile)
-                dstfile = os.path.join(self.rtlsimpath, modfile)
-                if os.path.isfile(dstfile):
-                    self.print_log(type='I', msg='Using externally generated source: %s' % modfile)
-                else:
-                    self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
-                    self.copy_or_relink(src=srcfile,dst=dstfile)
-
-            # copy additional VHDL files
-            for entfile in self.vhdlentityfiles:
-                srcfile = os.path.join(self.vhdlsrcpath, entfile)
-                dstfile = os.path.join(self.rtlsimpath, entfile)
-                if os.path.isfile(dstfile):
-                    self.print_log(type='I', msg='Using externally generated source: %s' % entfile)
-                else:
-                    self.print_log(type='I', msg='Copying %s to %s' % (srcfile, dstfile))
-                    self.copy_or_relink(src=srcfile,dst=dstfile)
+        # Append testbench to rtlfiles
+        if tb_bname not in self.rtlfiles:
+            self.rtlfiles += [tb_bname]
 
         # flush cached writes to disk
         output = subprocess.check_output("sync %s" % self.rtlsimpath, shell=True)
@@ -902,8 +867,13 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                 Add the probes in the simulation as you wish.
                 To finish the simulation, run the simulation to end and exit.""")
 
-        output = subprocess.check_output(self._rtlcmd, shell=True);
-        self.print_log(type='I', msg='Simulator output:\n'+output.decode('utf-8'))
+        try:
+            output = subprocess.check_output(self._rtlcmd, shell=True)
+            self.print_log(type='I', msg='Simulator output:\n'+output.decode('utf-8'))
+        except subprocess.CalledProcessError as e:
+            output = e.output
+            self.print_log(type='F', msg='Simulator output:\n'+output.decode('utf-8'))
+
 
         count=0
         files_ok=False

--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -432,9 +432,6 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         '''
         if not hasattr(self, '_vlogmodulefiles'):
             self._vlogmodulefiles = []
-            for module in self.rtlfiles:
-                if os.path.splitext(module)[1] in [".sv", ".v"]:
-                    self._vlogmodulefiles += [module]
         return self._vlogmodulefiles
     @vlogmodulefiles.setter
     def vlogmodulefiles(self,value):
@@ -498,9 +495,6 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         '''
         if not hasattr(self, '_vhdlentityfiles'):
             self._vhdlentityfiles = []
-            for module in self.rtlfiles:
-                if os.path.splitext(module)[1] in [".vhd", ".vhdl"]:
-                    self._vhdlentityfiles += [module]
         return self._vhdlentityfiles
     @vhdlentityfiles.setter
     def vhdlentityfiles(self,value):
@@ -747,6 +741,26 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                         and val.dir == 'in':
                     # Data must be properly shaped
                     self.iofile_bundle.Members[ioname].Data=self.IOS.Members[ioname].Data
+
+    def extract_vlogfiles(self):
+        """Return extracted verilog files from ``self.rtlfiles``
+        """
+        vlogfiles = []
+        for module in self.rtlfiles:
+            _, file_ext = os.path.splitext(module)
+            if file_ext in [".sv", ".v"]:
+                vlogfiles += [module]
+        return vlogfiles
+
+    def extract_vhdlfiles(self):
+        """Return extracted vhdl files from ``self.rtlfiles``
+        """
+        vhdlfiles = []
+        for module in self.rtlfiles:
+            _, file_ext = os.path.splitext(module)
+            if file_ext in [".vhd", ".vhdl"]:
+                vhdlfiles += [module]
+        return vhdlfiles
 
     # Define if the signals are signed or not
     # Can these be deducted?

--- a/rtl/ghdl/ghdl.py
+++ b/rtl/ghdl/ghdl.py
@@ -20,8 +20,7 @@ class ghdl(thesdk):
         if vlogmodulesstring != '':
             self.print_log(type='W', msg="GHDL does not support Verilog+VHDL cosimulation, ignoring additional Verilog files.")
         # We need to compile VHDL source and testbench anyway
-        vhdlcompcmd = ( 'ghdl -a -Wall -Wno-unused --std=08 --workdir=' + self.rtlworkpath + ' ' + vhdlmodulesstring 
-                + ' ' + self.simdut + ' ' + self.simtb )
+        vhdlcompcmd = ( 'ghdl -a -Wall -Wno-unused --std=08 --workdir=' + self.rtlworkpath + ' ' + vhdlmodulesstring )
         vhdlanalysiscmd = ( 'ghdl -e --std=08 --workdir=' + self.rtlworkpath + ' ' + 'tb_' + self.name )
 
 

--- a/rtl/ghdl/ghdl.py
+++ b/rtl/ghdl/ghdl.py
@@ -13,9 +13,9 @@ class ghdl(thesdk):
         if not os.path.exists(self.rtlworkpath):
             os.mkdir(self.rtlworkpath)
         vlogmodulesstring=' '.join(self.vloglibfilemodules + [ self.rtlsimpath + '/'+ 
-            str(param) for param in self.vlogmodulefiles ])
+            str(param) for param in self.extract_vlogfiles() ])
         vhdlmodulesstring=' '.join(self.vhdllibfileentities + [ self.rtlsimpath + '/'+ 
-            str(param) for param in self.vhdlentityfiles])
+            str(param) for param in self.extract_vhdlfiles()])
 
         if vlogmodulesstring != '':
             self.print_log(type='W', msg="GHDL does not support Verilog+VHDL cosimulation, ignoring additional Verilog files.")

--- a/rtl/icarus/icarus.py
+++ b/rtl/icarus/icarus.py
@@ -22,7 +22,7 @@ class icarus(thesdk,metaclass=abc.ABCMeta):
             self.print_log(type='W', msg="Icarus does not support Verilog+VHDL cosimulation, ignoring additional VHDL files.")
 
         vlogcompcmd = ( 'iverilog -Wall -v -g2012 -o ' + self.rtlworkpath + '/' + self.name
-    	            + ' ' + self.simtb + ' ' + self.simdut + ' ' + vlogmodulesstring)
+                    + ' ' + vlogmodulesstring)
         gstring = ' '.join([ 
                                 ('-g ' + str(param) +'='+ str(val[1])) 
                                 for param,val in self.rtlparameters.items() 

--- a/rtl/icarus/icarus.py
+++ b/rtl/icarus/icarus.py
@@ -16,7 +16,7 @@ class icarus(thesdk,metaclass=abc.ABCMeta):
         vlogmodulesstring=' '.join(self.vloglibfilemodules + [ self.rtlsimpath + '/'+ 
             str(param) for param in self.extract_vlogfiles() ])
         vhdlmodulesstring=' '.join([ self.rtlsimpath + '/'+ 
-            str(param) for param in self.extract_vlogfiles()])
+            str(param) for param in self.extract_vhdlfiles()])
 
         if vhdlmodulesstring != '':
             self.print_log(type='W', msg="Icarus does not support Verilog+VHDL cosimulation, ignoring additional VHDL files.")

--- a/rtl/icarus/icarus.py
+++ b/rtl/icarus/icarus.py
@@ -14,9 +14,9 @@ class icarus(thesdk,metaclass=abc.ABCMeta):
         if not os.path.exists(self.rtlworkpath):
             os.mkdir(self.rtlworkpath)
         vlogmodulesstring=' '.join(self.vloglibfilemodules + [ self.rtlsimpath + '/'+ 
-            str(param) for param in self.vlogmodulefiles ])
+            str(param) for param in self.extract_vlogfiles() ])
         vhdlmodulesstring=' '.join([ self.rtlsimpath + '/'+ 
-            str(param) for param in self.vhdlentityfiles])
+            str(param) for param in self.extract_vlogfiles()])
 
         if vhdlmodulesstring != '':
             self.print_log(type='W', msg="Icarus does not support Verilog+VHDL cosimulation, ignoring additional VHDL files.")

--- a/rtl/questasim/questasim.py
+++ b/rtl/questasim/questasim.py
@@ -59,6 +59,8 @@ class questasim(thesdk):
             first = True
             lang = None
             for module in comp_list:
+                # Check if the module is in vlogmodulefiles or vhdlentityfiles
+                # Same entry should contain modules from one language only
                 if module in self.vlogmodulefiles:
                     if first:
                         lang = "sv"


### PR DESCRIPTION
Introduce a new rtl propety, `rtlfiles`, to hold both verilog and vhdl files.

Compile order is determined by the order of modules in `rtlfiles`. Thus, you can now define compile order, with an arbitrary mix of `vcom` and `vlog` commands. 

This MR also contains a quality-of-life improvement, which will print out the error message produced by simulator, instead of the command that caused it.