### PR TITLE
Add setter for name

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -271,6 +271,9 @@ class rtl(questasim,icarus,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
         if not hasattr(self, '_name'):
             self._name=os.path.splitext(os.path.basename(self._classfile))[0]
         return self._name
+    @name.setter
+    def name(self, name):
+        self._name = name
 
     @property
     def rtlmisc(self):


### PR DESCRIPTION
Being able to set the name allows defining the top level verilog file and module name

For example, the SDK entity might be called `acorechip`, but the top level file and module could be called `ACoreWithQSPI.v` and `ACoreWithQSPI`, respectively.