### PR TITLE
changes to imports for better readability and better exception handling

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -14,19 +14,14 @@ Initially written by Marko Kosunen, 2017
 import os
 import sys
 import subprocess
-import shlex
-from abc import *
-import numpy as np
-import pandas as pd
-from functools import reduce
 import shutil
 import re
 
 #TheSyDeKick modules
-if not (os.path.abspath('../../thesdk') in sys.path):
+if (os.path.abspath('../../thesdk') not in sys.path):
     sys.path.append(os.path.abspath('../../thesdk'))
-from thesdk import *
-from rtl.connector import indent, rtl_connector_bundle, verilog_connector_bundle
+from thesdk import thesdk, ABCMeta, time
+from rtl.connector import rtl_connector_bundle 
 from rtl.testbench import testbench as vtb
 from rtl.rtl_iofile import rtl_iofile as rtl_iofile
 # Simulator modules
@@ -37,7 +32,7 @@ from rtl.questasim.questasim import questasim as questasim
 from rtl.ghdl.ghdl import ghdl as ghdl
 from rtl.verilator.verilator import verilator as verilator
 
-class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
+class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=ABCMeta):
     """Adding this class as a superclass enforces the definitions
     for rtl simulations in the subclasses.
 
@@ -139,11 +134,16 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             text = match.group(2)
         else:
             self.print_log(type='F', msg=f"Invalid rtl_timescale string: {val}. Allowed e.g. 1ps")
-        if text == "ms": number *= 1e-3
-        elif text == "us": number *= 1e-6
-        elif text == "ns": number *= 1e-9
-        elif text == "ps": number *= 1e-12
-        elif text == "fs": number *= 1e-15
+        if text == "ms":
+            number *= 1e-3
+        elif text == "us":
+            number *= 1e-6
+        elif text == "ns":
+            number *= 1e-9
+        elif text == "ps":
+            number *= 1e-12
+        elif text == "fs":
+            number *= 1e-15
         else:
             self.print_log(type='F', msg=f"Invalid rtl_timescale unit: {val}. Allowed ms,us,ns,ps,fs")
         return number
@@ -161,11 +161,16 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             text = match.group(2)
         else:
             self.print_log(type='F', msg=f"Invalid rtl_timeprecision string: {val}. Allowed e.g. 1ps")
-        if text == "ms": number *= 1e-3
-        elif text == "us": number *= 1e-6
-        elif text == "ns": number *= 1e-9
-        elif text == "ps": number *= 1e-12
-        elif text == "fs": number *= 1e-15
+        if text == "ms":
+            number *= 1e-3
+        elif text == "us":
+            number *= 1e-6
+        elif text == "ns":
+            number *= 1e-9
+        elif text == "ps":
+            number *= 1e-12
+        elif text == "fs":
+            number *= 1e-15
         else:
             self.print_log(type='F', msg=f"Invalid rtl_timeprecision unit: {val}. Allowed ms,us,ns,ps,fs")
         return number
@@ -320,7 +325,7 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                 if not os.path.exists(self._rtlsimpath):
                     self.print_log(type='I', msg='Creating %s' % self._rtlsimpath)
                     os.makedirs(self._rtlsimpath)
-            except:
+            except Exception:
                 self.print_log(type='E', msg='Failed to create %s' % self.rtlsimpath)
         return self._rtlsimpath
 
@@ -340,14 +345,14 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                         else:
                             os.remove(targetpath)
                         self.print_log(type='I',msg='Removing %s' % targetpath)
-            except:
+            except Exception:
                 self.print_log(type='W',msg='Could not remove %s' % targetpath)
 
             if not self.preserve_rtlfiles:
                 try:
                     shutil.rmtree(self.rtlsimpath)
                     self.print_log(type='I',msg='Removing %s' % self.rtlsimpath)
-                except:
+                except Exception:
                     self.print_log(type='W',msg='Could not remove %s' %self.rtlsimpath)
 
     @property
@@ -417,7 +422,7 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
             try:
                 shutil.rmtree(self.rtlworkpath)
                 self.print_log(type='D',msg='Removing %s' % self.rtlworkpath)
-            except:
+            except Exception:
                 self.print_log(type='W',msg='Could not remove %s' %self.rtlworkpath)
 
     @property
@@ -480,7 +485,7 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                                 self._vloglibfilemodules.extend(modulefiles)
                         except Exception as e:
                             self.print_log(type='F',msg='Could not read verilog module files from VLOGLIBFILE:\n\t%s' % e)
-            except:
+            except Exception:
                  self._vloglibfilemodules = []
         return self._vloglibfilemodules
     @vloglibfilemodules.setter
@@ -542,7 +547,7 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                                 self._vhdllibfileentities.extend(modulefiles)
                         except Exception as e:
                             self.print_log(type='F',msg='Could not read verilog module files from VHDLLIBFILE:\n\t%s' % e)
-            except:
+            except Exception:
                  self._vhdllibfileentities = []
         return self._vhdllibfileentities
 
@@ -915,7 +920,7 @@ class rtl(questasim,icarus,verilator,ghdl,vhdl,sv,thesdk,metaclass=abc.ABCMeta):
                 try:
                     #Still keep the file in the infiles list
                     os.remove(file.name)
-                except:
+                except Exception:
                     pass
 
         if self.interactive_rtl:

--- a/rtl/connector.py
+++ b/rtl/connector.py
@@ -9,22 +9,25 @@ returns definition strings according to given 'lang' paramenter
 
 Written by Marko Kosunen 20190109 marko.kosunen@aalto.fi
 """
-import os
-from thesdk import *
+import time
+import regex as re
+from thesdk import thesdk
+from thesdk.bundle import Bundle
 from rtl.sv.verilog_connector import verilog_connector
 from rtl.vhdl.vhdl_connector import vhdl_connector
 
 class rtl_connector(thesdk):
-    def __init__(self, **kwargs):
-        ''' Executes init of module_common, thus having the same attributes and
-        parameters.
-
-        Parameters
-        ----------
-            **kwargs :
-               See module module_common
-
-        '''
+    # Not sure why this is here
+    # def __init__(self, **kwargs):
+    #     ''' Executes init of module_common, thus having the same attributes and
+    #     parameters.
+    #
+    #     Parameters
+    #     ----------
+    #         **kwargs :
+    #            See module module_common
+    #
+    #     '''
 
 
     def __init__(self,**kwargs):
@@ -113,11 +116,11 @@ class rtl_connector(thesdk):
         return self._ll
     @ll.setter
     def ll(self,value):
-        if type(value) == str:
+        if type(value) is str:
             #Try to evaluate string
             try:
                 self._ll = eval(value)
-            except:
+            except Exception:
                 self._ll = value
         else:
             self._ll = value
@@ -136,11 +139,11 @@ class rtl_connector(thesdk):
         return self._rl
     @rl.setter
     def rl(self,value):
-        if type(value) == str:
+        if type(value) is str:
             #Try to evaluate string
             try:
                 self._rl = eval(value)
-            except:
+            except Exception:
                 self._rl = value
         else:
             self._rl = value

--- a/rtl/icarus/icarus.py
+++ b/rtl/icarus/icarus.py
@@ -7,10 +7,9 @@ properties and methods for RTL class
 
 Initially written by Marko Kosunen 20221030
 """
-from thesdk import *
-import pdb
+from thesdk import thesdk, ABCMeta, os
 
-class icarus(thesdk,metaclass=abc.ABCMeta):
+class icarus(thesdk,metaclass=ABCMeta):
     @property
     def icarus_rtlcmd(self):
         submission=self.lsf_submission

--- a/rtl/module.py
+++ b/rtl/module.py
@@ -12,12 +12,8 @@ python environment.
 Initially written by Marko Kosunen, 2017
 
 """
-import os
-from thesdk import *
-from rtl import *
+from thesdk import thesdk
 from copy import deepcopy
-from rtl.connector import verilog_connector
-from rtl.connector import verilog_connector_bundle
 from rtl.module_common import module_common
 from rtl.sv.verilog_module import verilog_module
 from rtl.vhdl.vhdl_entity import vhdl_entity

--- a/rtl/module_common.py
+++ b/rtl/module_common.py
@@ -7,8 +7,8 @@ Class containing common properties and methods for all language dependent module
 Initially written by Marko Kosunen, 28.10.2022
 """
 import os
-from thesdk import *
-from rtl import *
+from thesdk import thesdk
+from abc import abstractmethod
 from copy import deepcopy
 
 class module_common(thesdk):

--- a/rtl/rtl_iofile.py
+++ b/rtl/rtl_iofile.py
@@ -8,20 +8,12 @@ for TheSyDeKick RTL intereface.
 
 Restructured from verilog_iofile by Marko Kosunen, marko.kosunen@aalto.fi 2023
 """
-import os
-import sys
-import pdb
-from abc import * 
-from thesdk import *
-from thesdk.iofile import iofile
 import numpy as np
-import pandas as pd
 import sortedcontainers as sc
 from rtl.rtl_iofile_common import rtl_iofile_common
 from rtl.sv.verilog_iofile import verilog_iofile
 from rtl.sv.verilog_iofile_obsoletes import verilog_iofile_obsoletes
 from rtl.vhdl.vhdl_iofile import vhdl_iofile
-from rtl.connector import indent
 
 class rtl_iofile(verilog_iofile_obsoletes,rtl_iofile_common):
     '''
@@ -59,7 +51,7 @@ class rtl_iofile(verilog_iofile_obsoletes,rtl_iofile_common):
                    sets the ioformat attribute.
         '''
         #This is a redundant check, but does not hurt.to have it here too.
-        if parent==None:
+        if parent is None:
             self.print_log(type='F', msg="Parent of RTL input file not given")
         try:  
             super(rtl_iofile_common,self).__init__(parent=parent,**kwargs)
@@ -68,7 +60,7 @@ class rtl_iofile(verilog_iofile_obsoletes,rtl_iofile_common):
 
             self._ioformat=kwargs.get('ioformat','%d') #by default, the io values are decimal integer numbers
 
-        except:
+        except Exception:
             self.print_log(type='F', msg="RTL IO file definition failed")
 
         self._DictData = None  # data structure for event-based IO data
@@ -305,7 +297,7 @@ class rtl_iofile(verilog_iofile_obsoletes,rtl_iofile_common):
     def Data(self, value):
         # convert value to equivalent SortedDict representation
         if self.iotype=='event':
-            if self.DictData == None:
+            if self.DictData is None:
                 self._DictData = sc.SortedDict()
             for row in value:
                 self.DictData[row[0]] = row[1:]
@@ -344,17 +336,6 @@ class rtl_iofile(verilog_iofile_obsoletes,rtl_iofile_common):
     @rtl_io_condition.setter
     def rtl_io_condition(self,value):
         self.langmodule.rtl_io_condition=value
-
-    def rtl_io_condition_append(self,**kwargs ):
-        '''Append new condition string to `rtl_io_condition`
-
-        Parameters
-        ----------
-        **kwargs :
-           cond : str
-
-        '''
-        self.langmodule.rtl_io_condition_append(**kwargs)
 
     @property 
     def rtl_io_sync(self):

--- a/rtl/rtl_iofile_common.py
+++ b/rtl/rtl_iofile_common.py
@@ -1,12 +1,5 @@
-import os
-import sys
-import pdb
-from abc import * 
-from thesdk import *
 from thesdk.iofile import iofile
-import numpy as np
-import pandas as pd
-import sortedcontainers as sc
+
 """
 ========================
 RTL IOfile common module 

--- a/rtl/sv/sv.py
+++ b/rtl/sv/sv.py
@@ -8,10 +8,10 @@ are used by simulator specific classes.
 
 Initially written by Marko Kosunen 30.10.20200, marko.kosunen@aalto.fi
 """
-from thesdk import *
+from thesdk import thesdk, ABCMeta 
 from rtl.rtl_iofile import rtl_iofile as rtl_iofile
 
-class sv(thesdk,metaclass=abc.ABCMeta):
+class sv(thesdk,metaclass=ABCMeta):
 
     @property
     def vlogsimtb(self):
@@ -133,14 +133,14 @@ class sv(thesdk,metaclass=abc.ABCMeta):
                     # Connect them to DUT
                     try:
                         self.dut.ios.Members[connector.name].connect=connector
-                    except:
+                    except Exception:
                         pass
             # If input is not a file, look for corresponding file definition
             elif ioname in self.iofile_bundle.Members:
                 val=self.iofile_bundle.Members[ioname]
                 for name in val.ionames:
                     # [TODO] Sanity check, only floating inputs make sense.
-                    if not name in self.tb.connectors.Members.keys():
+                    if name not in self.tb.connectors.Members.keys():
                         self.print_log(type='I',
                                 msg='Creating non-existent IO connector %s for testbench' %(name))
                         self.tb.connectors.new(name=name, cls='reg')

--- a/rtl/sv/verilog_testbench.py
+++ b/rtl/sv/verilog_testbench.py
@@ -10,11 +10,7 @@ Extends `testbench_common`.
 Initially written by Marko Kosunen 20190108, marko.kosunen@aalto.fi
 Refactored from 'testbench' by Marko Kosunen 20221119, marko.kosunen@aalto.fi
 """
-import os
-import sys
-import pdb
-from rtl import indent
-from rtl.connector import rtl_connector
+from rtl.connector import rtl_connector, indent
 from rtl.testbench_common import testbench_common
 
 class verilog_testbench(testbench_common):
@@ -244,7 +240,7 @@ class verilog_testbench(testbench_common):
                         # Connect them to DUT
                         try:
                             self.dut.ios.Members[connector.name].connect=connector
-                        except:
+                        except Exception:
                             pass
         # Copy iofile simulation parameters to testbench
         for name, val in self.iofile_bundle.Members.items():

--- a/rtl/verilator/verilator.py
+++ b/rtl/verilator/verilator.py
@@ -7,10 +7,8 @@ properties and methods for RTL class
 
 Initially written by Aleksi Korsman, 2022
 """
-from thesdk import *
-import pdb
-
-class verilator(thesdk,metaclass=abc.ABCMeta):
+from thesdk import thesdk, ABCMeta, os
+class verilator(thesdk,metaclass=ABCMeta):
     @property
     def verilator_rtlcmd(self):
         submission=self.lsf_submission

--- a/rtl/vhdl/vhdl.py
+++ b/rtl/vhdl/vhdl.py
@@ -9,10 +9,10 @@ are used by the simulator specific classes.
 Initially written by Marko Kosunen 30.10.20200, marko.kosunen@aalto.fi 
 """
 
-from thesdk import *
+from thesdk import thesdk, ABCMeta
 from rtl.rtl_iofile import rtl_iofile as rtl_iofile
 
-class vhdl(thesdk,metaclass=abc.ABCMeta):
+class vhdl(thesdk,metaclass=ABCMeta):
     @property
     def vhdlsimtb(self):
         ''' Name of the VHDL testbench

--- a/rtl/vhdl/vhdl_testbench.py
+++ b/rtl/vhdl/vhdl_testbench.py
@@ -10,11 +10,7 @@ Extends `testbench_common`.
 Initially written by Marko Kosunen 20190108, marko.kosunen@aalto.fi
 Derived from 'verilog_testbench' by Marko Kosunen 20230523, marko.kosunen@aalto.fi
 """
-import os
-import sys
-import pdb
-from rtl import indent
-from rtl.connector import rtl_connector
+from rtl.connector import rtl_connector, indent
 from rtl.testbench_common import testbench_common
 
 class vhdl_testbench(testbench_common):
@@ -265,7 +261,7 @@ class vhdl_testbench(testbench_common):
                         # Connect them to DUT
                         try: 
                             self.dut.ios.Members[connector.name].connect=connector
-                        except:
+                        except Exception:
                             pass
         # Copy iofile simulation parameters to testbench
         for name, val in self.iofile_bundle.Members.items():


### PR DESCRIPTION
Commented what I see as a redundant constructor in `rtl/connector.py`, it should be removed in case it truly is.

Cleaned up imports by using explicit imports for better readability and modified bare except: as specified by PEP8, because leaving it like this catches exceptions, such as `KeyboardInterrupt` which is usually undesired