### PR TITLE
Fix for verilator arguments and default sim opt args

### DIFF
--- a/rtl/__init__.py
+++ b/rtl/__init__.py
@@ -255,11 +255,11 @@ class rtl(
                 self._sim_opt_dict = self.questasim_sim_opt_dict
             else:
                 self._sim_opt_dict = {
-                    "no-opt": "",
-                    "opt-visible": "",
-                    "full-opt": "",
-                    "top-visible": "",
-                    "top-dut-visible": "",
+                    "no-opt": [],
+                    "opt-visible": [],
+                    "full-opt": [],
+                    "top-visible": [],
+                    "top-dut-visible": [],
                 }
 
         return self._sim_opt_dict

--- a/rtl/testbench_common.py
+++ b/rtl/testbench_common.py
@@ -169,7 +169,7 @@ class testbench_common(module):
                 + self.parent.rtlsimpath
                 + "/"
                 + self.parent.name
-                + '_dump.vcd");\n'
+                + '_dump.fst");\n'
             )
             dump_str += "  $dumpvars(0, tb_" + self.parent.name + ");\nend \n"
         else:

--- a/rtl/testbench_common.py
+++ b/rtl/testbench_common.py
@@ -169,7 +169,7 @@ class testbench_common(module):
                 + self.parent.rtlsimpath
                 + "/"
                 + self.parent.name
-                + '_dump.fst");\n'
+                + '_dump.vcd");\n'
             )
             dump_str += "  $dumpvars(0, tb_" + self.parent.name + ");\nend \n"
         else:

--- a/rtl/verilator/verilator.py
+++ b/rtl/verilator/verilator.py
@@ -39,7 +39,7 @@ class verilator(thesdk, metaclass=abc.ABCMeta):
             )
 
         vlogcompcmd = (
-            "verilator -Wall --Wno-lint --binary --trace --timing "
+            "verilator -Wall --Wno-lint --binary --trace-fst --timing "
             + " ".join(self.vlogcompargs)
             + " "
             + " ".join(self.vlogsimargs)
@@ -81,13 +81,13 @@ class verilator(thesdk, metaclass=abc.ABCMeta):
                 + " && "
                 + "./Vtb_"
                 + self.name
-                + " && gtkwave "
-                + dostring
-                + " "
-                + self.rtlsimpath
-                + "/"
-                + self.name
-                + "_dump.vcd"
+                #+ " && gtkwave "
+                #+ dostring
+                #+ " "
+                #+ self.rtlsimpath
+                #+ "/"
+                #+ self.name
+                #+ "_dump.vcd"
             )
         else:
             rtlsimcmd = "cd " + self.rtlworkpath + " &&  ./Vtb_" + self.name

--- a/rtl/verilator/verilator.py
+++ b/rtl/verilator/verilator.py
@@ -39,7 +39,12 @@ class verilator(thesdk, metaclass=abc.ABCMeta):
             )
 
         vlogcompcmd = (
-            "verilator -Wall --Wno-lint --binary --trace --timing --Mdir "
+            "verilator -Wall --Wno-lint --binary --trace --timing "
+            + " ".join(self.vlogcompargs)
+            + " "
+            + " ".join(self.vlogsimargs)
+            + " "
+            + "--Mdir "
             + self.rtlworkpath
             + " "
             + self.simtb
@@ -54,9 +59,6 @@ class verilator(thesdk, metaclass=abc.ABCMeta):
                 for param, val in self.rtlparameters.items()
             ]
         )
-
-        # Still dont know what to do with these.
-        vlogsimargs = " ".join(self.vlogsimargs)
 
         fileparams = ""
         for name, file in self.iofile_bundle.Members.items():

--- a/rtl/verilator/verilator.py
+++ b/rtl/verilator/verilator.py
@@ -39,7 +39,7 @@ class verilator(thesdk, metaclass=abc.ABCMeta):
             )
 
         vlogcompcmd = (
-            "verilator -Wall --Wno-lint --binary --trace-fst --timing "
+            "verilator -Wall --Wno-lint --binary --trace --timing "
             + " ".join(self.vlogcompargs)
             + " "
             + " ".join(self.vlogsimargs)
@@ -81,13 +81,13 @@ class verilator(thesdk, metaclass=abc.ABCMeta):
                 + " && "
                 + "./Vtb_"
                 + self.name
-                #+ " && gtkwave "
-                #+ dostring
-                #+ " "
-                #+ self.rtlsimpath
-                #+ "/"
-                #+ self.name
-                #+ "_dump.vcd"
+                + " && gtkwave "
+                + dostring
+                + " "
+                + self.rtlsimpath
+                + "/"
+                + self.name
+                + "_dump.vcd"
             )
         else:
             rtlsimcmd = "cd " + self.rtlworkpath + " &&  ./Vtb_" + self.name


### PR DESCRIPTION
This PR does two things

- Set sim_opt_args as empty arrays instead of emtpy strings. This is in line with how vlogsimargs is used
- Support of vlogsimargs and vlogcompargs for verilator. Previously, there was no support