### PR TITLE
Fix icarus backend when vloglibfilemodules is provided

### DIFF
--- a/rtl/icarus/icarus.py
+++ b/rtl/icarus/icarus.py
@@ -9,6 +9,7 @@ Initially written by Marko Kosunen 20221030
 """
 
 from thesdk import *
+import os
 import pdb
 
 
@@ -19,10 +20,9 @@ class icarus(thesdk, metaclass=abc.ABCMeta):
         if not os.path.exists(self.rtlworkpath):
             os.mkdir(self.rtlworkpath)
         vlogmodulesstring = " ".join(
-            self.vloglibfilemodules
-            + [
-                self.rtlsimpath + "/" + str(param)
-                for param in self.extract_vlogfiles()
+            [
+                os.path.join(self.rtlsimpath, modulepath)
+                for modulepath in self.rtlfiles
             ]
         )
         vhdlmodulesstring = " ".join(


### PR DESCRIPTION
Icarus simulations break when `vloglibfilemodules` (e.g. external memory simulation models) are provided due to manual path parsing logic with string operations. `self.vloglibfilemodules` are already included in `self.rtlfiles`. Modify icarus backend logic to more closely match working questa backend logic and perform path concatenations using `os.path.join()`.